### PR TITLE
Add Node script for test results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-    "scripts": {
-        "postinstall": "patch-package --error-on-fail"
-    },
-    "workspaces": [
-        "resources/assets/v1",
-        "resources/assets/v2"
-    ],
-    "devDependencies": {
-        "postcss": "^8.4.47"
-    }
+  "scripts": {
+    "postinstall": "patch-package --error-on-fail",
+    "test:php": "node scripts/print-test-results.js"
+  },
+  "workspaces": [
+    "resources/assets/v1",
+    "resources/assets/v2"
+  ],
+  "devDependencies": {
+    "postcss": "^8.4.47"
+  }
 }

--- a/scripts/print-test-results.js
+++ b/scripts/print-test-results.js
@@ -1,0 +1,10 @@
+const { spawn } = require('child_process');
+
+const phpunit = spawn('php', ['vendor/bin/phpunit', '-c', 'phpunit.xml'], {
+  stdio: 'inherit'
+});
+
+phpunit.on('exit', (code) => {
+  console.log(`Test run completed with exit code ${code}`);
+  process.exit(code);
+});


### PR DESCRIPTION
## Summary
- add `scripts/print-test-results.js`
- update root `package.json` with a `test:php` script

## Testing
- `./vendor/bin/phpunit --testsuite unit --no-coverage` *(fails: Errors)*
- `bash .ci/phpstan.sh` *(fails: Missing app key)*
- `bash .ci/phpmd.sh` *(fails with deprecated warnings)*
- `node scripts/print-test-results.js` *(fails: Fatal error)*

------
https://chatgpt.com/codex/tasks/task_e_688bd5dab3bc8326b14d98575546f6c9