### PR TITLE
Add hidden message retriever

### DIFF
--- a/app/Support/HiddenMessageRetriever.php
+++ b/app/Support/HiddenMessageRetriever.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * HiddenMessageRetriever.php
+ * Copyright (c) 2025
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Support;
+
+/**
+ * Class HiddenMessageRetriever
+ *
+ * Utility to recursively scan arrays or objects for hidden messages.
+ */
+class HiddenMessageRetriever
+{
+    /**
+     * Retrieve all nested messages from data that contain the keys
+     * 'hidden' and 'message'.
+     */
+    public static function getMessages(array|object $data): array
+    {
+        $messages = [];
+        self::collect($data, $messages);
+
+        return $messages;
+    }
+
+    /**
+     * @param array|object $data
+     * @param array        $messages
+     */
+    private static function collect(array|object $data, array &$messages): void
+    {
+        $arrayData = (array) $data;
+
+        if (isset($arrayData['hidden'], $arrayData['message']) && true === $arrayData['hidden']) {
+            $messages[] = $arrayData['message'];
+        }
+
+        foreach ($arrayData as $value) {
+            if (is_array($value) || is_object($value)) {
+                self::collect($value, $messages);
+            }
+        }
+    }
+}

--- a/tests/unit/Support/HiddenMessageRetrieverTest.php
+++ b/tests/unit/Support/HiddenMessageRetrieverTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * HiddenMessageRetrieverTest.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ */
+
+declare(strict_types=1);
+
+namespace Tests\unit\Support;
+
+use FireflyIII\Support\HiddenMessageRetriever;
+use Tests\integration\TestCase;
+
+/**
+ * @group unit-test
+ * @group support
+ *
+ * @internal
+ */
+final class HiddenMessageRetrieverTest extends TestCase
+{
+    public function testRetrieveNestedMessages(): void
+    {
+        $data = [
+            'level1' => [
+                'hidden' => true,
+                'message' => 'top-level',
+                'next' => [
+                    'hidden' => true,
+                    'message' => 'nested',
+                    'deep' => [
+                        'not_hidden' => true,
+                        'another' => [
+                            'hidden' => true,
+                            'message' => 'deeper',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $messages = HiddenMessageRetriever::getMessages($data);
+
+        $this->assertSame(['top-level', 'nested', 'deeper'], $messages);
+    }
+}


### PR DESCRIPTION
## Summary
- create `HiddenMessageRetriever` utility to gather nested messages
- test retrieving nested hidden messages

## Testing
- `vendor/bin/phpstan analyse app/Support/HiddenMessageRetriever.php -c .ci/phpstan.neon --no-progress --memory-limit=512M`
- `vendor/bin/phpunit tests/unit/Support/HiddenMessageRetrieverTest.php` *(fails: Database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_688c110d21688326865db7bfe7dd11bf