### PR TITLE
Add Plaid logs migration

### DIFF
--- a/database/migrations/2025_08_01_134600_create_ai_extension_plaid_logs_table.php
+++ b/database/migrations/2025_08_01_134600_create_ai_extension_plaid_logs_table.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * 2025_08_01_134600_create_ai_extension_plaid_logs_table.php
+ * Copyright (c) 2025 james@firefly-iii.org.
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('ai_extension_plaid_logs')) {
+            Schema::create('ai_extension_plaid_logs', function (Blueprint $table): void {
+                $table->increments('id');
+                $table->timestamps();
+                $table->softDeletes();
+                $table->integer('user_id', false, true)->nullable();
+                $table->string('event', 255)->nullable();
+                $table->longText('message')->nullable();
+                $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_extension_plaid_logs');
+    }
+};


### PR DESCRIPTION
## Summary
- create Plaid logs migration with licensing header

## Testing
- `composer run unit-test`
- `./vendor/bin/phpstan analyse -c .ci/phpstan.neon --no-progress --error-format=table --memory-limit=1G` *(fails: Found 487 errors)*
- `.ci/phpmd.sh` *(deprecation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688cc2d8f3f48326b9d3847193e4a19b