### PR TITLE
Add Monte-Carlo goal projection integration test

### DIFF
--- a/tests/integration/Api/GoalProjectionTest.php
+++ b/tests/integration/Api/GoalProjectionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\integration\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\integration\TestCase;
+use Override;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class GoalProjectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!isset($this->user)) {
+            $this->user = $this->createAuthenticatedUser();
+        }
+        $this->actingAs($this->user);
+    }
+
+    public function testProjectionEndpointReturnsStructure(): void
+    {
+        $response = $this->getJson(route('api.v1.goal-projection', ['goal' => 1]));
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'date',
+                    'lower',
+                    'upper',
+                    'median',
+                ],
+            ],
+            'meta' => [
+                'iterations',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GoalProjectionTest` integration test

## Testing
- `./.ci/all.sh` *(fails: PHPStan exit code 127)*
- `npm run test:php` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_688cd3ace28c8326a3573416c5a47515