### PR TITLE
Add goals projection API

### DIFF
--- a/app/Modules/AI/Goals/MonteCarloSimulationService.php
+++ b/app/Modules/AI/Goals/MonteCarloSimulationService.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * MonteCarloSimulationService.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * Copyright (c) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Modules\AI\Goals;
+
+/**
+ * Class MonteCarloSimulationService
+ *
+ * Performs a simple Monte-Carlo simulation to project goal growth over time.
+ */
+class MonteCarloSimulationService
+{
+    private function randomNormal(float $mean = 0.0, float $stdev = 1.0): float
+    {
+        // Box-Muller transform
+        $u1 = mt_rand() / mt_getrandmax();
+        $u2 = mt_rand() / mt_getrandmax();
+        $z0 = \sqrt(-2.0 * \log($u1)) * \cos(2 * M_PI * $u2);
+
+        return $z0 * $stdev + $mean;
+    }
+
+    /**
+     * Run the simulation.
+     *
+     * @return array<int, array<string, float|int>>
+     */
+    public function project(float $initial, float $mean, float $stdev, int $years, int $runs = 1000): array
+    {
+        $steps      = $years * 12; // monthly steps
+        $projection = [];
+
+        for ($step = 1; $step <= $steps; ++$step) {
+            $total        = 0.0;
+            for ($run = 0; $run < $runs; ++$run) {
+                $value = $initial;
+                for ($i = 0; $i < $step; ++$i) {
+                    $value *= 1 + $this->randomNormal($mean / 12, $stdev / \sqrt(12));
+                }
+                $total += $value;
+            }
+            $average      = $total / $runs;
+            $projection[] = [
+                'month'  => $step,
+                'amount' => $average,
+            ];
+        }
+
+        return $projection;
+    }
+}

--- a/app/Modules/AI/Goals/ProjectionController.php
+++ b/app/Modules/AI/Goals/ProjectionController.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * ProjectionController.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * Copyright (c) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Modules\AI\Goals;
+
+use FireflyIII\Api\V1\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Class ProjectionController
+ *
+ * Returns a Monte-Carlo projection for a goal.
+ */
+class ProjectionController extends Controller
+{
+    private MonteCarloSimulationService $service;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->service = app(MonteCarloSimulationService::class);
+    }
+
+    public function __invoke(Request $request, string $id): JsonResponse
+    {
+        $initial    = (float) $request->get('initial', 0);
+        $mean       = (float) $request->get('mean', 0.05);
+        $stdev      = (float) $request->get('stdev', 0.02);
+        $years      = (int) $request->get('years', 5);
+
+        $projection = $this->service->project($initial, $mean, $stdev, $years);
+
+        return response()->json([
+            'goal_id'    => $id,
+            'projection' => $projection,
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 use FireflyIII\Modules\AI\Plaid\PlaidHookController;
+use FireflyIII\Modules\AI\Goals\ProjectionController;
 
 /*
  *
@@ -1000,3 +1001,4 @@ Route::group(
     }
 );
 Route::post('v1/plaid-hook', PlaidHookController::class)->name('api.v1.plaid-hook');
+Route::get('v1/goals/{id}/projection', ProjectionController::class)->name('api.v1.goals.projection');


### PR DESCRIPTION
## Summary
- implement Monte-Carlo simulation service
- add projection controller for goals
- register `v1/goals/{id}/projection` route

## Testing
- `./vendor/bin/phpstan analyse -c .ci/phpstan.neon --no-progress --error-format=table`
- `composer unit-test` *(fails: Errors! Tests: 374, Errors: 374)*
- `composer integration-test` *(fails: Errors! Tests: 38, Errors: 38)*

------
https://chatgpt.com/codex/tasks/task_e_688cd3ac67488326a6c5b660ca83c3cf