### PR TITLE
Improve Plaid webhook and test setup

### DIFF
--- a/.ci/phpstan.sh
+++ b/.ci/phpstan.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Do static code analysis.
 if [[ $GITHUB_ACTIONS = "" ]]
 then
-    ./vendor/bin/phpstan analyse -c .ci/phpstan.neon --error-format=table > phpstan-report.txt
+    ./vendor/bin/phpstan analyse -c .ci/phpstan.neon --memory-limit=1G --error-format=table > phpstan-report.txt
     EXIT_CODE=$?
     echo "The PHPstan report can be found in phpstan-report.txt. Exit code is $EXIT_CODE."
 fi

--- a/app/Modules/AI/Plaid/PlaidHookController.php
+++ b/app/Modules/AI/Plaid/PlaidHookController.php
@@ -76,9 +76,20 @@ class PlaidHookController extends Controller
 
     private function verifySignature(Request $request, string $secret): void
     {
-        $signature = (string) $request->header('Plaid-Verification');
+        $header    = (string) $request->header('Plaid-Verification');
         $payload   = $request->getContent();
-        $expected  = hash_hmac('sha256', $payload, $secret, false);
+
+        parse_str(str_replace(',', '&', $header), $parts);
+        $timestamp = $parts['t'] ?? '';
+        $signature = $parts['v1'] ?? '';
+
+        if ('' === $timestamp || '' === $signature) {
+            Log::warning('Invalid Plaid verification header.');
+
+            throw new BadHttpHeaderException('Invalid Plaid signature');
+        }
+
+        $expected  = hash_hmac('sha256', $timestamp.'.'.$payload, $secret);
 
         if (!hash_equals($expected, $signature)) {
             Log::warning('Invalid Plaid HMAC header.');

--- a/scripts/print-test-results.js
+++ b/scripts/print-test-results.js
@@ -1,6 +1,6 @@
 const { spawn } = require('child_process');
 
-const phpunit = spawn('php', ['vendor/bin/phpunit', '-c', 'phpunit.xml'], {
+const phpunit = spawn('php', ['-d', 'memory_limit=1G', 'vendor/bin/phpunit', '-c', 'phpunit.xml'], {
   stdio: 'inherit'
 });
 


### PR DESCRIPTION
## Summary
- refine Plaid webhook signature parsing
- bump phpstan memory limit to 1G
- allow phpunit to use more memory

## Testing
- `bash .ci/phpstan.sh` *(fails: Found 3333 errors)*
- `bash .ci/phpmd.sh` *(produced only deprecation warnings)*
- `npm run test:php` *(fails: 416 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d1b4c807c83269532fc7eaf0c46da