### PR TITLE
Add Monte-Carlo projection integration test

### DIFF
--- a/tests/integration/Api/GoalProjectionTest.php
+++ b/tests/integration/Api/GoalProjectionTest.php
@@ -20,6 +20,11 @@ final class GoalProjectionTest extends TestCase
     #[Override]
     protected function setUp(): void
     {
+        $dbPath = dirname(__DIR__, 3).'/storage/database/database.sqlite';
+        if (!file_exists($dbPath)) {
+            @mkdir(dirname($dbPath), 0o777, true);
+            touch($dbPath);
+        }
         parent::setUp();
         if (!isset($this->user)) {
             $this->user = $this->createAuthenticatedUser();
@@ -32,6 +37,30 @@ final class GoalProjectionTest extends TestCase
         $response = $this->getJson(route('api.v1.goal-projection', ['goal' => 1]));
 
         $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'date',
+                    'lower',
+                    'upper',
+                    'median',
+                ],
+            ],
+            'meta' => [
+                'iterations',
+            ],
+        ]);
+    }
+
+    public function testYearsParameterControlsNumberOfResults(): void
+    {
+        $response = $this->getJson(route('api.v1.goal-projection', [
+            'goal' => 1,
+            'years' => 2,
+        ]));
+
+        $response->assertOk();
+        $response->assertJsonCount(24, 'data');
         $response->assertJsonStructure([
             'data' => [
                 '*' => [


### PR DESCRIPTION
## Summary
- add a new integration test verifying the years parameter
- ensure integration tests create their SQLite database file

## Testing
- `vendor/bin/phpunit --filter GoalProjectionTest`
- `.ci/phpstan.sh` *(fails: Found 489 errors)*
- `.ci/phpmd.sh` *(fails: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688d30e12bac8326b98987a183b532bb