### PR TITLE
Add goal projection endpoint

### DIFF
--- a/app/Modules/AI/Goals/MonteCarloSimulationService.php
+++ b/app/Modules/AI/Goals/MonteCarloSimulationService.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace FireflyIII\Modules\AI\Goals;
 
+use function now;
+
 /**
  * Class MonteCarloSimulationService
  *
@@ -69,5 +71,35 @@ class MonteCarloSimulationService
         }
 
         return $projection;
+    }
+
+    /**
+     * Return a projection formatted for JSON responses.
+     *
+     * @return array<string, mixed>
+     */
+    public function projectJson(float $initial, float $mean, float $stdev, int $years, int $runs = 1000): array
+    {
+        $raw   = $this->project($initial, $mean, $stdev, $years, $runs);
+
+        $start = now()->startOfMonth();
+        $data  = array_map(
+            static function (array $entry) use ($start) {
+                return [
+                    'date'   => $start->copy()->addMonths($entry['month'])->format('Y-m-d'),
+                    'lower'  => $entry['amount'] * 0.9,
+                    'upper'  => $entry['amount'] * 1.1,
+                    'median' => $entry['amount'],
+                ];
+            },
+            $raw
+        );
+
+        return [
+            'data' => $data,
+            'meta' => [
+                'iterations' => $runs,
+            ],
+        ];
     }
 }

--- a/app/Modules/AI/Goals/ProjectionController.php
+++ b/app/Modules/AI/Goals/ProjectionController.php
@@ -51,25 +51,8 @@ class ProjectionController extends Controller
         $stdev      = (float) $request->get('stdev', 0.02);
         $years      = (int) $request->get('years', 5);
 
-        $raw = $this->service->project($initial, $mean, $stdev, $years);
+        $result = $this->service->projectJson($initial, $mean, $stdev, $years);
 
-        $data = array_map(
-            static function (array $entry) {
-                return [
-                    'date'   => '2024-01-01',
-                    'lower'  => $entry['amount'] * 0.9,
-                    'upper'  => $entry['amount'] * 1.1,
-                    'median' => $entry['amount'],
-                ];
-            },
-            $raw
-        );
-
-        return response()->json([
-            'data' => $data,
-            'meta' => [
-                'iterations' => 0,
-            ],
-        ]);
+        return response()->json($result);
     }
 }


### PR DESCRIPTION
## Summary
- implement Monte Carlo projection service with JSON format
- expose `GET /api/v1/goals/{id}/projection` endpoint
- register projection route
- optimize date calculation in projection service

## Testing
- `vendor/bin/phpstan --configuration=.ci/phpstan.neon --no-progress --memory-limit=1G`
- `composer unit-test`


------
https://chatgpt.com/codex/tasks/task_e_688d30e09fec83268b4704bc7f861768