### PR TITLE
feat: add AI strategy signal endpoint

### DIFF
--- a/app/Modules/AI/Strategy/BrokerSdk.php
+++ b/app/Modules/AI/Strategy/BrokerSdk.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * BrokerSdk.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * Copyright (c) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Modules\AI\Strategy;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Class BrokerSdk
+ *
+ * Sends trading signals to a configured broker implementation.
+ */
+class BrokerSdk
+{
+    /**
+     * Forward the given signal to the configured broker.
+     */
+    public function sendSignal(array $payload): void
+    {
+        $driver = config('services.broker.driver');
+        $url    = match ($driver) {
+            'alpaca'    => config('services.broker.alpaca_url'),
+            'freqtrade' => config('services.broker.freqtrade_url'),
+            default     => null,
+        };
+
+        if (null === $url) {
+            Log::warning('No broker configured for trading signals.');
+
+            return;
+        }
+
+        try {
+            Http::post($url, $payload);
+        } catch (Throwable $e) {
+            Log::error(sprintf('Failed to forward signal: %s', $e->getMessage()));
+        }
+    }
+}

--- a/app/Modules/AI/Strategy/SignalController.php
+++ b/app/Modules/AI/Strategy/SignalController.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * SignalController.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * Copyright (c) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Modules\AI\Strategy;
+
+use FireflyIII\Api\V1\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Class SignalController
+ *
+ * Receives trading signals from AI modules and forwards them to brokers.
+ */
+class SignalController extends Controller
+{
+    private BrokerSdk $broker;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->broker = app(BrokerSdk::class);
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'asset'      => 'required|string',
+            'action'     => 'required|in:buy,sell',
+            'confidence' => 'required|numeric|between:0,1',
+        ]);
+
+        $this->broker->sendSignal($validated);
+
+        return response()->json([], 202);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -69,4 +69,10 @@ return [
     'plaid'     => [
         'webhook_secret' => env('PLAID_WEBHOOK_SECRET'),
     ],
+
+    'broker'    => [
+        'driver'        => env('BROKER_DRIVER', 'alpaca'),
+        'alpaca_url'    => env('ALPACA_SIGNAL_URL'),
+        'freqtrade_url' => env('FREQTRADE_SIGNAL_URL'),
+    ],
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Route;
 use FireflyIII\Modules\AI\Plaid\PlaidHookController;
 use FireflyIII\Modules\AI\Goals\ProjectionController;
+use FireflyIII\Modules\AI\Strategy\SignalController;
 
 /*
  *
@@ -1001,6 +1002,7 @@ Route::group(
     }
 );
 Route::post('v1/plaid-hook', PlaidHookController::class)->name('api.v1.plaid-hook');
+Route::post('v1/signals', SignalController::class)->name('api.v1.signals');
 Route::get('v1/goals/{id}/projection', ProjectionController::class)
     ->name('api.v1.goals.projection');
 Route::get('v1/goals/{goal}/projection', ProjectionController::class)

--- a/tests/integration/Api/SignalControllerTest.php
+++ b/tests/integration/Api/SignalControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\integration\Api;
+
+use FireflyIII\Modules\AI\Strategy\BrokerSdk;
+use FireflyIII\Http\Middleware\Authenticate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\integration\TestCase;
+use Mockery;
+use Override;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class SignalControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $dbPath = dirname(__DIR__, 3).'/storage/database/database.sqlite';
+        if (!file_exists($dbPath)) {
+            @mkdir(dirname($dbPath), 0o777, true);
+            touch($dbPath);
+        }
+        parent::setUp();
+        if (!isset($this->user)) {
+            $this->user = $this->createAuthenticatedUser();
+        }
+        $this->actingAs($this->user);
+        $this->withoutMiddleware(Authenticate::class);
+    }
+
+    public function testValidSignal(): void
+    {
+        $sdk = Mockery::mock(BrokerSdk::class);
+        $sdk->shouldReceive('sendSignal')->once();
+        $this->app->instance(BrokerSdk::class, $sdk);
+
+        $response = $this->postJson('/api/v1/signals', [
+            'asset'      => 'BTC',
+            'action'     => 'buy',
+            'confidence' => 0.9,
+        ]);
+
+        $response->assertStatus(202);
+    }
+
+    public function testInvalidSignal(): void
+    {
+        $response = $this->postJson('/api/v1/signals', [
+            'asset'      => 'BTC',
+            'confidence' => 1.5,
+        ]);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary
- add SignalController to validate and forward AI trading signals
- integrate BrokerSdk and broker service configuration
- wire up POST /api/v1/signals route with tests

## Testing
- `vendor/bin/phpstan analyse app/Modules/AI/Strategy --no-progress --memory-limit=512M`
- `vendor/bin/phpunit tests/integration/Api/SignalControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_688e57122c8483268cc549a30a143785