### PR TITLE
feat: enforce OPA authorization for API mutations

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -31,6 +31,7 @@ use FireflyIII\Http\Middleware\InstallationId;
 use FireflyIII\Http\Middleware\Installer;
 use FireflyIII\Http\Middleware\InterestingMessage;
 use FireflyIII\Http\Middleware\IsAdmin;
+use FireflyIII\Http\Middleware\OpaMiddleware;
 use FireflyIII\Http\Middleware\Range;
 use FireflyIII\Http\Middleware\RedirectIfAuthenticated;
 use FireflyIII\Http\Middleware\SecureHeaders;
@@ -74,6 +75,7 @@ class Kernel extends HttpKernel
             'bindings'   => Binder::class,
             'can'        => Authorize::class,
             'guest'      => RedirectIfAuthenticated::class,
+            'opa'        => OpaMiddleware::class,
             'throttle'   => ThrottleRequests::class,
         ];
     protected $middlewareGroups

--- a/app/Http/Middleware/OpaMiddleware.php
+++ b/app/Http/Middleware/OpaMiddleware.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * OpaMiddleware.php
+ * Copyright (c) 2024 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+namespace FireflyIII\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Class OpaMiddleware
+ */
+class OpaMiddleware
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (!in_array($request->getMethod(), ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+            return $next($request);
+        }
+
+        try {
+            $response = Http::post('http://localhost:8181/v1/data/finance/authz', [
+                'input' => [
+                    'method' => $request->getMethod(),
+                    'path'   => $request->path(),
+                ],
+            ]);
+            $data    = $response->json();
+            $allowed = $data['result']['allow'] ?? $data['result'] ?? false;
+        } catch (\Throwable $e) {
+            $allowed = false;
+        }
+
+        if ($allowed) {
+            return $next($request);
+        }
+
+        return response()->json(['message' => 'Forbidden'], 403);
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -43,7 +43,7 @@ class RouteServiceProvider extends ServiceProvider
     {
         $this->routes(function (): void {
             Route::prefix('api')
-                ->middleware('api')
+                ->middleware(['api', 'opa'])
                 ->namespace($this->namespace)
                 ->group(base_path('routes/api.php'))
             ;


### PR DESCRIPTION
## Summary
- add middleware querying OPA sidecar for mutation authorization
- register middleware and apply to API routes

## Testing
- `./.ci/phpstan.sh` *(fails: Scanned file /workspace/finance-engine/_ide_helper does not exist)*
- `composer unit-test` *(fails: Database file at path [/workspace/finance-engine/storage/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_688e8b21e140832698950ee38d0e4b45