### PR TITLE
feat: add strategy signals Liquibase script

### DIFF
--- a/database/liquibase/ai_extension_strategy_signals.yaml
+++ b/database/liquibase/ai_extension_strategy_signals.yaml
@@ -1,0 +1,51 @@
+databaseChangeLog:
+  - changeSet:
+      id: ai-extension-strategy-signals
+      author: openai
+      changes:
+        - createTable:
+            tableName: ai_extension_strategy_signals
+            schemaName: firefly
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT AUTO_INCREMENT
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: created_at
+                  type: datetime
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: datetime
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: deleted_at
+                  type: datetime
+                  constraints:
+                    nullable: true
+              - column:
+                  name: user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+              - column:
+                  name: strategy
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: signal
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: message
+                  type: CLOB
+                  constraints:
+                    nullable: true

--- a/database/liquibase/db.changelog-master.yaml
+++ b/database/liquibase/db.changelog-master.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      file: ai_extension_strategy_signals.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
## Summary
- add Liquibase changelog for `ai_extension_strategy_signals` table
- include new changelog in master file

## Testing
- `composer unit-test` *(fails: Could not open input file: vendor/bin/phpunit)*
- `composer install --no-interaction` *(fails: ext-sodium missing)*
- `apt-get install -y php8.4-sodium` *(fails: Unable to locate package)*
- `vendor/bin/phpstan --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e90b90e088326a726262500221e19