### PR TITLE
feat: async Plaid transaction batching with metrics

### DIFF
--- a/app/Jobs/ProcessPlaidTransactions.php
+++ b/app/Jobs/ProcessPlaidTransactions.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * ProcessPlaidTransactions.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * Copyright (c) 2024
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Jobs;
+
+use FireflyIII\Models\UserGroup;
+use FireflyIII\User;
+use FireflyIII\Repositories\TransactionGroup\TransactionGroupRepositoryInterface;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Class ProcessPlaidTransactions
+ */
+class ProcessPlaidTransactions implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function __construct(private array $payload) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(TransactionGroupRepositoryInterface $groupRepository): void
+    {
+        $user        = User::find((int) ($this->payload['user_id'] ?? 0));
+        $userGroup   = UserGroup::find((int) ($this->payload['user_group_id'] ?? 0));
+        $transactions = $this->payload['transactions'] ?? [];
+
+        if (!$user instanceof User || !$userGroup instanceof UserGroup || !is_array($transactions)) {
+            Log::warning('Invalid data for Plaid transaction processing.');
+
+            return;
+        }
+
+        $groupRepository->setUser($user);
+        $groupRepository->setUserGroup($userGroup);
+
+        $data = $this->payload;
+        $data['user']       = $user;
+        $data['user_group'] = $userGroup;
+
+        $start = microtime(true);
+        $groupRepository->store($data);
+        $duration   = microtime(true) - $start;
+        $count      = count($transactions);
+        $throughput = $duration > 0 ? $count / $duration : $count;
+
+        Log::info(sprintf('Processed %d Plaid transactions at %.2f tx/sec', $count, $throughput));
+        if ($throughput < 5) {
+            Log::warning(sprintf('Plaid throughput below target: %.2f tx/sec', $throughput));
+        }
+    }
+}
+

--- a/app/Modules/AI/Plaid/PlaidHookController.php
+++ b/app/Modules/AI/Plaid/PlaidHookController.php
@@ -27,6 +27,7 @@ namespace FireflyIII\Modules\AI\Plaid;
 
 use FireflyIII\Api\V1\Controllers\Controller;
 use FireflyIII\Exceptions\BadHttpHeaderException;
+use FireflyIII\Jobs\ProcessPlaidTransactions;
 use FireflyIII\Repositories\TransactionGroup\TransactionGroupRepositoryInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -65,13 +66,21 @@ class PlaidHookController extends Controller
 
         $this->verifySignature($request, $secret);
 
-        $data               = $request->all();
-        $data['user']       = auth()->user();
-        $data['user_group'] = $this->userGroup;
+        $payload                = $request->all();
+        $payload['user_id']     = (int) auth()->id();
+        $payload['user_group_id'] = (int) $this->userGroup->id;
 
-        $this->groupRepository->store($data);
+        $transactions           = $payload['transactions'] ?? [];
+        $basePayload            = $payload;
+        unset($basePayload['transactions']);
 
-        return response()->json([], 201);
+        foreach (array_chunk(is_array($transactions) ? $transactions : [], 5) as $chunk) {
+            $chunkPayload                 = $basePayload;
+            $chunkPayload['transactions'] = $chunk;
+            ProcessPlaidTransactions::dispatch($chunkPayload);
+        }
+
+        return response()->json([], 202);
     }
 
     private function verifySignature(Request $request, string $secret): void


### PR DESCRIPTION
## Summary
- queue Plaid webhook processing and split payloads into batches of five transactions
- log throughput per batch and warn when below target

## Testing
- `APP_KEY=base64:gWey6/Gcqjmr6rf2Rs+F2iNYM/h3x373d9Q13PvFBOI= vendor/bin/phpstan analyse app/Modules/AI/Plaid app/Jobs/ProcessPlaidTransactions.php --memory-limit=1G`
- `vendor/bin/phpunit tests/integration/Api/PlaidHookTest.php`


------
https://chatgpt.com/codex/tasks/task_e_688ea08d82348326931b9031440c3fd2