### PR TITLE
Fix failing tests and configure suite

### DIFF
--- a/scripts/print-test-results.js
+++ b/scripts/print-test-results.js
@@ -1,6 +1,6 @@
 const { spawn } = require('child_process');
 
-const phpunit = spawn('php', ['-d', 'memory_limit=1G', 'vendor/bin/phpunit', '-c', 'phpunit.xml'], {
+const phpunit = spawn('php', ['-d', 'memory_limit=1G', 'vendor/bin/phpunit', '-c', 'phpunit.xml', '--no-coverage'], {
   stdio: 'inherit'
 });
 

--- a/tests/integration/Api/SignalControllerTest.php
+++ b/tests/integration/Api/SignalControllerTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Tests\integration\Api;
 
 use FireflyIII\Modules\AI\Strategy\BrokerSdk;
-use FireflyIII\Http\Middleware\Authenticate;
+use FireflyIII\Http\Middleware\OpaMiddleware;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\integration\TestCase;
 use Mockery;
 use Override;
+use function Safe\mkdir;
+use function Safe\touch;
 
 /**
  * @internal
@@ -20,20 +22,22 @@ final class SignalControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    private $user;
+
     #[Override]
     protected function setUp(): void
     {
         $dbPath = dirname(__DIR__, 3).'/storage/database/database.sqlite';
         if (!file_exists($dbPath)) {
-            @mkdir(dirname($dbPath), 0o777, true);
+            mkdir(dirname($dbPath), 0o777, true);
             touch($dbPath);
         }
         parent::setUp();
         if (!isset($this->user)) {
             $this->user = $this->createAuthenticatedUser();
         }
-        $this->actingAs($this->user);
-        $this->withoutMiddleware(Authenticate::class);
+        $this->actingAs($this->user, 'api');
+        $this->withoutMiddleware(OpaMiddleware::class);
     }
 
     public function testValidSignal(): void

--- a/tests/integration/Api/SignalEndpointTest.php
+++ b/tests/integration/Api/SignalEndpointTest.php
@@ -7,6 +7,9 @@ namespace Tests\integration\Api;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Tests\integration\TestCase;
+use FireflyIII\Http\Middleware\OpaMiddleware;
+use function Safe\mkdir;
+use function Safe\touch;
 use Override;
 
 /**
@@ -25,40 +28,48 @@ final class SignalEndpointTest extends TestCase
     {
         $dbPath = dirname(__DIR__, 3).'/storage/database/database.sqlite';
         if (!file_exists($dbPath)) {
-            @mkdir(dirname($dbPath), 0o777, true);
+            mkdir(dirname($dbPath), 0o777, true);
             touch($dbPath);
         }
         parent::setUp();
         if (!isset($this->user)) {
             $this->user = $this->createAuthenticatedUser();
         }
-        $this->actingAs($this->user);
+        $this->actingAs($this->user, 'api');
+        $this->withoutMiddleware(OpaMiddleware::class);
     }
 
     public function testValidationErrorForMissingPayload(): void
     {
-        $response = $this->postJson('/api/v1/signal', []);
+        $response = $this->postJson('/api/v1/signals', []);
 
         $response->assertStatus(422);
-        $response->assertJsonValidationErrors(['url', 'payload']);
+        $response->assertJsonValidationErrors(['asset', 'action', 'confidence']);
     }
 
     public function testForwardingOfValidPayload(): void
     {
+        config([
+            'services.broker.driver' => 'freqtrade',
+            'services.broker.freqtrade_url' => 'https://example.com/hook',
+        ]);
         Http::fake([
             'https://example.com/hook' => Http::response(['status' => 'ok'], 200),
         ]);
 
-        $response = $this->postJson('/api/v1/signal', [
-            'url' => 'https://example.com/hook',
-            'payload' => ['foo' => 'bar'],
+        $response = $this->postJson('/api/v1/signals', [
+            'asset' => 'BTC',
+            'action' => 'buy',
+            'confidence' => 0.9,
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(202);
 
         Http::assertSent(static function ($request): bool {
             return 'https://example.com/hook' === $request->url()
-                && $request['foo'] === 'bar';
+                && 'BTC' === $request['asset']
+                && 'buy' === $request['action']
+                && 0.9 === (float) $request['confidence'];
         });
     }
 }

--- a/tests/unit/Support/NavigationEndOfPeriodTest.php
+++ b/tests/unit/Support/NavigationEndOfPeriodTest.php
@@ -51,10 +51,16 @@ final class NavigationEndOfPeriodTest extends TestCase
     }
 
     #[DataProvider('provideDates')]
-    public function testGivenADateAndFrequencyWhenCalculateTheDateThenReturnsTheExpectedDateSuccessful(string $frequency, Carbon $from, Carbon $expected): void
+    /**
+     * @param Carbon|callable $expected
+     */
+    public function testGivenADateAndFrequencyWhenCalculateTheDateThenReturnsTheExpectedDateSuccessful(string $frequency, Carbon $from, Carbon|callable $expected): void
     {
-        $period = clone $this->navigation->endOfPeriod($from, $frequency);
-        $this->assertSame($expected->toDateString(), $period->toDateString());
+        Carbon::setTestNow($from);
+        $period       = clone $this->navigation->endOfPeriod($from, $frequency);
+        $expectedDate = is_callable($expected) ? $expected($from) : $expected;
+        Carbon::setTestNow();
+        self::assertSame($expectedDate->toDateString(), $period->toDateString());
     }
 
     public static function provideDates(): iterable
@@ -99,8 +105,7 @@ final class NavigationEndOfPeriodTest extends TestCase
 
         yield 'last365' => ['last365', Carbon::now(), Carbon::now()->addDays(365)->endOfDay()];
 
-        yield 'MTD' => ['MTD', Carbon::now(),
-            Carbon::now()->isSameMonth(Carbon::now()) ? Carbon::now()->endOfDay() : Carbon::now()->endOfMonth()];
+        yield 'MTD' => ['MTD', Carbon::now(), fn () => today()->endOfDay()];
 
         yield 'QTD' => ['QTD', Carbon::now(), Carbon::now()->firstOfQuarter()->startOfDay()];
 
@@ -115,7 +120,7 @@ final class NavigationEndOfPeriodTest extends TestCase
         Log::spy();
 
         $period          = $this->navigation->endOfPeriod($from, $frequency);
-        $this->assertSame($expected->toDateString(), $period->toDateString());
+        self::assertSame($expected->toDateString(), $period->toDateString());
         $expectedMessage = sprintf('Cannot do endOfPeriod for $repeat_freq "%s"', $frequency);
 
         Log::shouldHaveReceived('error', [$expectedMessage]);


### PR DESCRIPTION
## Summary
- use phpunit without coverage for compatibility
- stabilize navigation period tests using frozen time
- align signal API tests with auth and broker configuration

## Testing
- `npm run test:php`
- `APP_ENV=testing ./vendor/bin/phpstan analyse tests/integration/Api/SignalControllerTest.php tests/integration/Api/SignalEndpointTest.php tests/unit/Support/NavigationEndOfPeriodTest.php --memory-limit=512M`


------
https://chatgpt.com/codex/tasks/task_e_688ea08dff2c8326974d115b9c60f07c