### PR TITLE
feat: add debt simulation endpoint

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * DebtController.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * Copyright (c) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Api\V1\Controllers\Simulations;
+
+use FireflyIII\Api\V1\Controllers\Controller;
+use FireflyIII\Api\V1\Requests\Simulations\DebtRequest;
+use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Class DebtController
+ *
+ * Endpoint that returns ranked payoff plans for outstanding debts.
+ */
+class DebtController extends Controller
+{
+    private DebtSimulationService $service;
+
+    public function __construct(DebtSimulationService $service)
+    {
+        parent::__construct();
+        $this->service = $service;
+    }
+
+    public function __invoke(DebtRequest $request): JsonResponse
+    {
+        $data  = $request->getData();
+        $plans = $this->service->simulate(
+            $data['user_id'],
+            $data['group_id'],
+            $data['accounts'],
+            (float) $data['monthly_budget'],
+            (int) $data['max_options']
+        );
+
+        return response()->json(['data' => $plans]);
+    }
+}

--- a/app/Api/V1/Requests/Simulations/DebtRequest.php
+++ b/app/Api/V1/Requests/Simulations/DebtRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * DebtRequest.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * Copyright (c) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Api\V1\Requests\Simulations;
+
+use FireflyIII\Support\Request\ChecksLogin;
+use FireflyIII\Support\Request\ConvertsDataTypes;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Class DebtRequest
+ *
+ * Validates the payload for the debt simulation endpoint.
+ */
+class DebtRequest extends FormRequest
+{
+    use ChecksLogin;
+    use ConvertsDataTypes;
+
+    /**
+     * Extract validated data with proper types.
+     *
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        return [
+            'user_id'        => $this->convertInteger('user_id'),
+            'group_id'       => $this->convertInteger('group_id'),
+            'accounts'       => $this->get('accounts', []),
+            'monthly_budget' => $this->convertFloat('monthly_budget'),
+            'max_options'    => $this->convertInteger('max_options'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function rules(): array
+    {
+        return [
+            'user_id'        => 'required|integer',
+            'group_id'       => 'required|integer',
+            'accounts'       => 'required|array|min:1',
+            'monthly_budget' => 'required|numeric|min:0',
+            'max_options'    => 'required|integer|min:1',
+        ];
+    }
+}

--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * DebtSimulationService.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * Copyright (c) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Modules\AI\Simulations;
+
+/**
+ * Class DebtSimulationService
+ *
+ * Generates simple payoff plans for a list of debt accounts.  Two strategies
+ * are supported: the "avalanche" method which prioritises the highest interest
+ * rate and the "snowball" method which targets the smallest balance first.
+ *
+ * The implementation is intentionally lightweight – it provides deterministic
+ * and easily testable output rather than a full financial model.  Each plan is
+ * returned with basic metrics and a deviation cost relative to the cheapest
+ * option.
+ */
+class DebtSimulationService
+{
+    /**
+     * Run the simulation.
+     *
+     * @param int   $userId        The owning user identifier.
+     * @param int   $groupId       The user group identifier.
+     * @param array $accounts      Array of accounts. Each entry must contain
+     *                             `id`, `balance` and `rate` (APR percentage).
+     * @param float $budget        Monthly budget available for repayments.
+     * @param int   $maxOptions    Maximum number of plans to return.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function simulate(int $userId, int $groupId, array $accounts, float $budget, int $maxOptions = 2): array
+    {
+        // Generate plans using two common strategies: avalanche and snowball.
+        $strategies = [
+            'avalanche' => fn(array $a, array $b) => $b['rate'] <=> $a['rate'],
+            'snowball'  => fn(array $a, array $b) => $a['balance'] <=> $b['balance'],
+        ];
+
+        $plans = [];
+        foreach ($strategies as $name => $sort) {
+            $ordered = $accounts;
+            usort($ordered, $sort);
+            $simulation = $this->simulateOrder($ordered, $budget);
+            $plans[]    = [
+                'strategy'       => $name,
+                'order'          => array_column($ordered, 'id'),
+                'metrics'        => $simulation,
+            ];
+            if (count($plans) >= $maxOptions) {
+                break;
+            }
+        }
+
+        // Rank plans by total interest paid (lowest is best).
+        usort($plans, static fn($a, $b) => $a['metrics']['interest'] <=> $b['metrics']['interest']);
+        $min = $plans[0]['metrics']['interest'] ?? 0.0;
+        foreach ($plans as $idx => &$plan) {
+            $plan['rank']           = $idx + 1;
+            $plan['deviation_cost'] = $plan['metrics']['interest'] - $min;
+        }
+
+        return $plans;
+    }
+
+    /**
+     * Simulate paying off accounts in the given order.
+     *
+     * @param array<int, array{id:int, balance:float, rate:float}> $accounts
+     * @param float                                                $budget
+     *
+     * @return array<string, float|int>
+     */
+    private function simulateOrder(array $accounts, float $budget): array
+    {
+        $balances = array_map(static fn($a) => $a['balance'], $accounts);
+        $rates    = array_map(static fn($a) => $a['rate'] / 100, $accounts);
+        $months   = 0;
+        $interest = 0.0;
+
+        while (array_sum($balances) > 0.01 && $months < 1200) { // cap to prevent infinite loops
+            // Apply monthly interest
+            foreach ($balances as $i => $balance) {
+                if ($balance <= 0) {
+                    continue;
+                }
+                $charge      = $balance * $rates[$i] / 12;
+                $balances[$i] += $charge;
+                $interest    += $charge;
+            }
+
+            $remaining = $budget;
+            foreach ($balances as $i => $balance) {
+                if ($balance <= 0 || $remaining <= 0) {
+                    continue;
+                }
+                $pay            = min($balance, $remaining);
+                $balances[$i]  -= $pay;
+                $remaining     -= $pay;
+            }
+            ++$months;
+        }
+
+        return [
+            'months'   => $months,
+            'interest' => $interest,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Facades\Route;
 use FireflyIII\Modules\AI\Plaid\PlaidHookController;
 use FireflyIII\Modules\AI\Goals\ProjectionController;
 use FireflyIII\Modules\AI\Strategy\SignalController;
+use FireflyIII\Api\V1\Controllers\Simulations\DebtController;
 
 /*
  *
@@ -1007,3 +1008,5 @@ Route::get('v1/goals/{id}/projection', ProjectionController::class)
     ->name('api.v1.goals.projection');
 Route::get('v1/goals/{goal}/projection', ProjectionController::class)
     ->name('api.v1.goal-projection');
+Route::post('v1/simulations/debt', DebtController::class)
+    ->name('api.v1.simulations.debt');

--- a/tests/integration/CreatesApplication.php
+++ b/tests/integration/CreatesApplication.php
@@ -38,6 +38,16 @@ trait CreatesApplication
      */
     public function createApplication()
     {
+        $databasePath = __DIR__.'/../../storage/database/database.sqlite';
+
+        if (! file_exists($databasePath)) {
+            if (! is_dir(dirname($databasePath))) {
+                mkdir(dirname($databasePath), 0777, true);
+            }
+
+            touch($databasePath);
+        }
+
         $app = require __DIR__.'/../../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();


### PR DESCRIPTION
## Summary
- add POST `/v1/simulations/debt` route
- implement debt payoff simulation service and controller
- validate debt simulation requests
- ensure sqlite database file is created for tests

## Testing
- `php -l app/Modules/AI/Simulations/DebtSimulationService.php`
- `php -l app/Api/V1/Requests/Simulations/DebtRequest.php`
- `php -l app/Api/V1/Controllers/Simulations/DebtController.php`
- `php -l tests/integration/CreatesApplication.php`
- `./vendor/bin/phpstan analyse app/Api/V1/Controllers/Simulations/DebtController.php app/Api/V1/Requests/Simulations/DebtRequest.php app/Modules/AI/Simulations/DebtSimulationService.php tests/integration/CreatesApplication.php --no-progress --level=1 --memory-limit=1G`
- `./vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_688eb0bd6f948326ae62396b3b19fb06