### PR TITLE
Require user ID and group validation on API requests

### DIFF
--- a/app/Api/V1/Controllers/Controller.php
+++ b/app/Api/V1/Controllers/Controller.php
@@ -82,6 +82,7 @@ abstract class Controller extends BaseController
         $this->middleware(
             function ($request, $next) {
                 $this->parameters = $this->getParameters();
+                $this->validateUserGroup($request);
                 if (auth()->check()) {
                     $language              = Steam::getLanguage();
                     $this->convertToNative = Amount::convertToNative();

--- a/app/Api/V2/Controllers/Controller.php
+++ b/app/Api/V2/Controllers/Controller.php
@@ -62,6 +62,7 @@ class Controller extends BaseController
         $this->middleware(
             function ($request, $next) {
                 $this->parameters = $this->getParameters();
+                $this->validateUserGroup($request);
 
                 return $next($request);
             }

--- a/app/Api/V2/Controllers/Summary/BasicController.php
+++ b/app/Api/V2/Controllers/Summary/BasicController.php
@@ -43,7 +43,6 @@ use FireflyIII\Repositories\Budget\OperationsRepositoryInterface;
 use FireflyIII\Repositories\Currency\CurrencyRepositoryInterface;
 use FireflyIII\Support\Http\Api\ExchangeRateConverter;
 use FireflyIII\Support\Http\Api\SummaryBalanceGrouped;
-use FireflyIII\Support\Http\Api\ValidatesUserGroupTrait;
 use FireflyIII\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
@@ -53,7 +52,6 @@ use Illuminate\Support\Facades\Log;
  */
 class BasicController extends Controller
 {
-    use ValidatesUserGroupTrait;
 
     private AvailableBudgetRepositoryInterface $abRepository;
     private AccountRepositoryInterface         $accountRepository;
@@ -77,7 +75,7 @@ class BasicController extends Controller
                 $this->currencyRepos     = app(CurrencyRepositoryInterface::class);
                 $this->opsRepository     = app(OperationsRepositoryInterface::class);
 
-                $userGroup               = $this->validateUserGroup($request);
+                $userGroup               = $this->userGroup ?? $this->validateUserGroup($request);
                 $this->abRepository->setUserGroup($userGroup);
                 $this->accountRepository->setUserGroup($userGroup);
                 $this->billRepository->setUserGroup($userGroup);

--- a/app/Support/Http/Api/ValidatesUserGroupTrait.php
+++ b/app/Support/Http/Api/ValidatesUserGroupTrait.php
@@ -58,15 +58,33 @@ trait ValidatesUserGroupTrait
         }
 
         /** @var User $user */
-        $user        = auth()->user();
-        $groupId     = 0;
-        if (!$request->has('user_group_id')) {
+        $user = auth()->user();
+
+        if (!$request->has('user_id')) {
+            Log::debug('validateUserGroup: request does not contain a user id.');
+
+            throw new AuthorizationException((string) trans('validation.no_access_user'));
+        }
+
+        $userId = (int) $request->get('user_id');
+        if ($userId !== (int) $user->id) {
+            Log::debug(sprintf('validateUserGroup: user #%d tried to access user #%d.', $user->id, $userId));
+
+            throw new AuthorizationException((string) trans('validation.no_access_user'));
+        }
+
+        $groupId = 0;
+        if ($request->has('group_id')) {
+            $groupId = (int) $request->get('group_id');
+            Log::debug(sprintf('validateUserGroup: user group submitted, search for memberships in group #%d.', $groupId));
+        }
+        if (!$request->has('group_id') && $request->has('user_group_id')) {
+            $groupId = (int) $request->get('user_group_id');
+            Log::debug(sprintf('validateUserGroup: legacy user group submitted, search for memberships in group #%d.', $groupId));
+        }
+        if (0 === $groupId) {
             $groupId = (int) $user->user_group_id;
             Log::debug(sprintf('validateUserGroup: no user group submitted, use default group #%d.', $groupId));
-        }
-        if ($request->has('user_group_id')) {
-            $groupId = (int) $request->get('user_group_id');
-            Log::debug(sprintf('validateUserGroup: user group submitted, search for memberships in group #%d.', $groupId));
         }
 
         /** @var UserGroupRepositoryInterface $repository */

--- a/resources/lang/en_US/validation.php
+++ b/resources/lang/en_US/validation.php
@@ -278,6 +278,7 @@ return [
 
     // no access to administration:
     'no_auth_user_group'               => 'You have to be logged in to access this administration.',
+    'no_access_user'                  => 'You do not have access rights for this user.',
     'no_access_user_group'             => 'You do not have the correct access rights for this administration.',
     'administration_owner_rename'      => 'You can\'t rename your standard administration.',
     'existing_mfa_code'                => 'Please enter a valid code',


### PR DESCRIPTION
## Summary
- Require `user_id` and optional `group_id` on API requests and validate that the authenticated user matches
- Enforce validation from base API controllers and use the validated group in summaries
- Add missing translation for user access checks

## Testing
- `vendor/bin/phpstan analyse app --no-progress --memory-limit=1G` *(fails: Found 492 errors)*
- `composer unit-test`

------
https://chatgpt.com/codex/tasks/task_e_688eb5e540488326b494c9efaee8d434