### PR TITLE
Add user scoped caching for debt simulations

### DIFF
--- a/app/Handlers/Observer/AccountObserver.php
+++ b/app/Handlers/Observer/AccountObserver.php
@@ -33,6 +33,7 @@ use FireflyIII\Repositories\Account\AccountRepositoryInterface;
 use FireflyIII\Repositories\Attachment\AttachmentRepositoryInterface;
 use FireflyIII\Support\Facades\Amount;
 use FireflyIII\Support\Http\Api\ExchangeRateConverter;
+use FireflyIII\Support\Cache\UserScopedCache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -45,6 +46,7 @@ class AccountObserver
     {
         //        Log::debug('Observe "created" of an account.');
         $this->updateNativeAmount($account);
+        UserScopedCache::flush($account->user_id, (int) $account->user_group_id);
     }
 
     private function updateNativeAmount(Account $account): void
@@ -103,11 +105,14 @@ class AccountObserver
 
         $account->notes()->delete();
         $account->locations()->delete();
+
+        UserScopedCache::flush($account->user_id, (int) $account->user_group_id);
     }
 
     public function updated(Account $account): void
     {
         //        Log::debug('Observe "updated" of an account.');
         $this->updateNativeAmount($account);
+        UserScopedCache::flush($account->user_id, (int) $account->user_group_id);
     }
 }

--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace FireflyIII\Modules\AI\Simulations;
 
+use FireflyIII\Support\Cache\UserScopedCache;
+
 /**
  * Class DebtSimulationService
  *
@@ -53,36 +55,46 @@ class DebtSimulationService
      */
     public function simulate(int $userId, int $groupId, array $accounts, float $budget, int $maxOptions = 2): array
     {
-        // Generate plans using two common strategies: avalanche and snowball.
-        $strategies = [
-            'avalanche' => fn(array $a, array $b) => $b['rate'] <=> $a['rate'],
-            'snowball'  => fn(array $a, array $b) => $a['balance'] <=> $b['balance'],
-        ];
+        $hash     = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
+        $cacheKey = 'debt-sim-' . $hash;
 
-        $plans = [];
-        foreach ($strategies as $name => $sort) {
-            $ordered = $accounts;
-            usort($ordered, $sort);
-            $simulation = $this->simulateOrder($ordered, $budget);
-            $plans[]    = [
-                'strategy'       => $name,
-                'order'          => array_column($ordered, 'id'),
-                'metrics'        => $simulation,
-            ];
-            if (count($plans) >= $maxOptions) {
-                break;
+        return UserScopedCache::remember(
+            $userId,
+            $groupId,
+            $cacheKey,
+            function () use ($accounts, $budget, $maxOptions): array {
+                // Generate plans using two common strategies: avalanche and snowball.
+                $strategies = [
+                    'avalanche' => fn(array $a, array $b) => $b['rate'] <=> $a['rate'],
+                    'snowball'  => fn(array $a, array $b) => $a['balance'] <=> $b['balance'],
+                ];
+
+                $plans = [];
+                foreach ($strategies as $name => $sort) {
+                    $ordered    = $accounts;
+                    usort($ordered, $sort);
+                    $simulation = $this->simulateOrder($ordered, $budget);
+                    $plans[]    = [
+                        'strategy' => $name,
+                        'order'    => array_column($ordered, 'id'),
+                        'metrics'  => $simulation,
+                    ];
+                    if (count($plans) >= $maxOptions) {
+                        break;
+                    }
+                }
+
+                // Rank plans by total interest paid (lowest is best).
+                usort($plans, static fn($a, $b) => $a['metrics']['interest'] <=> $b['metrics']['interest']);
+                $min = $plans[0]['metrics']['interest'] ?? 0.0;
+                foreach ($plans as $idx => &$plan) {
+                    $plan['rank']           = $idx + 1;
+                    $plan['deviation_cost'] = $plan['metrics']['interest'] - $min;
+                }
+
+                return $plans;
             }
-        }
-
-        // Rank plans by total interest paid (lowest is best).
-        usort($plans, static fn($a, $b) => $a['metrics']['interest'] <=> $b['metrics']['interest']);
-        $min = $plans[0]['metrics']['interest'] ?? 0.0;
-        foreach ($plans as $idx => &$plan) {
-            $plan['rank']           = $idx + 1;
-            $plan['deviation_cost'] = $plan['metrics']['interest'] - $min;
-        }
-
-        return $plans;
+        );
     }
 
     /**

--- a/app/Services/DebtSimulation/SimulationService.php
+++ b/app/Services/DebtSimulation/SimulationService.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 
 namespace FireflyIII\Services\DebtSimulation;
 
+use FireflyIII\Support\Cache\UserScopedCache;
+
 /**
  * Class SimulationService
  *
@@ -38,32 +40,44 @@ class SimulationService
     /**
      * Run simulations for all strategies.
      *
+     * @param int   $userId        The owning user identifier.
+     * @param int   $groupId       The user group identifier.
      * @param array $debts         Each debt should be an associative array with keys:
      *                             name, balance, rate (annual) and min_payment.
      * @param float $monthlyBudget Total monthly amount available for debt payments.
      *
      * @return array
      */
-    public function simulate(array $debts, float $monthlyBudget): array
+    public function simulate(int $userId, int $groupId, array $debts, float $monthlyBudget): array
     {
-        $results = [];
+        $hash     = hash('sha256', serialize([$debts, $monthlyBudget]));
+        $cacheKey = 'detailed-sim-' . $hash;
 
-        foreach (self::STRATEGIES as $strategy) {
-            $plan      = $this->generateSchedule($debts, $monthlyBudget, $strategy);
-            $results[] = array_merge(['strategy' => $strategy], $plan);
-        }
+        return UserScopedCache::remember(
+            $userId,
+            $groupId,
+            $cacheKey,
+            function () use ($debts, $monthlyBudget): array {
+                $results = [];
 
-        usort($results, static function (array $a, array $b): int {
-            return [$a['total_interest'], $a['months']] <=> [$b['total_interest'], $b['months']];
-        });
+                foreach (self::STRATEGIES as $strategy) {
+                    $plan      = $this->generateSchedule($debts, $monthlyBudget, $strategy);
+                    $results[] = array_merge(['strategy' => $strategy], $plan);
+                }
 
-        $bestTotalInterest = $results[0]['total_interest'] ?? 0.0;
-        foreach ($results as $i => &$result) {
-            $result['rank']              = $i + 1;
-            $result['cost_of_deviation'] = $result['total_interest'] - $bestTotalInterest;
-        }
+                usort($results, static function (array $a, array $b): int {
+                    return [$a['total_interest'], $a['months']] <=> [$b['total_interest'], $b['months']];
+                });
 
-        return $results;
+                $bestTotalInterest = $results[0]['total_interest'] ?? 0.0;
+                foreach ($results as $i => &$result) {
+                    $result['rank']              = $i + 1;
+                    $result['cost_of_deviation'] = $result['total_interest'] - $bestTotalInterest;
+                }
+
+                return $results;
+            }
+        );
     }
 
     /**

--- a/app/Support/Cache/UserScopedCache.php
+++ b/app/Support/Cache/UserScopedCache.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * UserScopedCache.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Support\Cache;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Simple helper around the cache store that namespaces keys by user and group.
+ * It also keeps track of stored keys so that all cached values for a given
+ * scope can be flushed when the underlying data changes.
+ */
+class UserScopedCache
+{
+    private static function prefix(int $userId, int $groupId): string
+    {
+        return sprintf('u:%d:g:%d', $userId, $groupId);
+    }
+
+    private static function indexKey(int $userId, int $groupId): string
+    {
+        return self::prefix($userId, $groupId) . ':keys';
+    }
+
+    public static function remember(int $userId, int $groupId, string $key, callable $callback, int $ttlSeconds = 3600)
+    {
+        $cacheKey = self::prefix($userId, $groupId) . ':' . $key;
+        if (Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
+        $value = $callback();
+        Cache::put($cacheKey, $value, $ttlSeconds);
+
+        $indexKey = self::indexKey($userId, $groupId);
+        $keys     = Cache::get($indexKey, []);
+        if (!in_array($cacheKey, $keys, true)) {
+            $keys[] = $cacheKey;
+            Cache::put($indexKey, $keys, $ttlSeconds);
+        }
+
+        return $value;
+    }
+
+    public static function forget(int $userId, int $groupId, string $key): void
+    {
+        $cacheKey = self::prefix($userId, $groupId) . ':' . $key;
+        Cache::forget($cacheKey);
+    }
+
+    public static function flush(int $userId, int $groupId): void
+    {
+        $indexKey = self::indexKey($userId, $groupId);
+        $keys     = Cache::pull($indexKey, []);
+        foreach ($keys as $cacheKey) {
+            Cache::forget($cacheKey);
+        }
+    }
+}

--- a/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * DebtSimulationServiceCachingTest.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ */
+
+declare(strict_types=1);
+
+namespace Tests\unit\Modules\AI;
+
+use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use FireflyIII\Support\Cache\UserScopedCache;
+use Illuminate\Support\Facades\Cache;
+use Tests\integration\TestCase;
+
+/**
+ * @group unit-test
+ * @group ai
+ *
+ * @internal
+ */
+final class DebtSimulationServiceCachingTest extends TestCase
+{
+    public function testCachesAndFlushesResults(): void
+    {
+        Cache::flush();
+
+        $service  = new DebtSimulationService();
+        $userId   = 1;
+        $groupId  = 1;
+        $accounts = [
+            ['id' => 1, 'balance' => 100.0, 'rate' => 5.0],
+        ];
+        $budget     = 50.0;
+        $maxOptions = 2;
+
+        $service->simulate($userId, $groupId, $accounts, $budget, $maxOptions);
+
+        $hash     = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
+        $cacheKey = sprintf('u:%d:g:%d:debt-sim-%s', $userId, $groupId, $hash);
+
+        $this->assertTrue(Cache::has($cacheKey));
+
+        UserScopedCache::flush($userId, $groupId);
+
+        $this->assertFalse(Cache::has($cacheKey));
+    }
+}


### PR DESCRIPTION
## Summary
- Cache debt simulation results per user/group to avoid recalculation
- Clear cached simulations when account records change
- Cover caching behaviour with unit test

## Testing
- `composer unit-test`
- `composer integration-test` *(fails: Invalid key supplied)*

------
https://chatgpt.com/codex/tasks/task_e_688eb5e62fc48326a9f2773d1643b77d