### PR TITLE
feat: include heuristic metadata in debt simulations

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -56,6 +56,9 @@ class DebtController extends Controller
             (int) $data['max_options']
         );
 
-        return response()->json(['data' => $plans]);
+        return response()->json([
+            'data' => $plans,
+            'meta' => ['ranking_heuristic' => DebtSimulationService::RANKING_HEURISTIC],
+        ]);
     }
 }

--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -41,6 +41,7 @@ use FireflyIII\Support\Cache\UserScopedCache;
  */
 class DebtSimulationService
 {
+    public const RANKING_HEURISTIC = 'interest_then_months';
     /**
      * Run the simulation.
      *
@@ -85,11 +86,17 @@ class DebtSimulationService
                 }
 
                 // Rank plans by total interest paid (lowest is best).
-                usort($plans, static fn($a, $b) => $a['metrics']['interest'] <=> $b['metrics']['interest']);
-                $min = $plans[0]['metrics']['interest'] ?? 0.0;
+                usort($plans, static fn($a, $b) => [$a['metrics']['interest'], $a['metrics']['months']] <=> [$b['metrics']['interest'], $b['metrics']['months']]);
+                $minInterest = $plans[0]['metrics']['interest'] ?? 0.0;
+                $minMonths   = $plans[0]['metrics']['months'] ?? 0;
                 foreach ($plans as $idx => &$plan) {
-                    $plan['rank']           = $idx + 1;
-                    $plan['deviation_cost'] = $plan['metrics']['interest'] - $min;
+                    $plan['rank']              = $idx + 1;
+                    $plan['deviation_cost']    = $plan['metrics']['interest'] - $minInterest;
+                    $plan['ranking_heuristic'] = self::RANKING_HEURISTIC;
+                    $plan['trade_offs']        = [
+                        'interest_diff' => $plan['metrics']['interest'] - $minInterest,
+                        'months_diff'   => $plan['metrics']['months'] - $minMonths,
+                    ];
                 }
 
                 return $plans;

--- a/app/Services/DebtSimulation/SimulationService.php
+++ b/app/Services/DebtSimulation/SimulationService.php
@@ -35,7 +35,8 @@ use FireflyIII\Support\Cache\UserScopedCache;
  */
 class SimulationService
 {
-    private const STRATEGIES = ['avalanche', 'snowball'];
+    private const STRATEGIES         = ['avalanche', 'snowball'];
+    private const RANKING_HEURISTIC = 'total_interest_then_months';
 
     /**
      * Run simulations for all strategies.
@@ -70,9 +71,15 @@ class SimulationService
                 });
 
                 $bestTotalInterest = $results[0]['total_interest'] ?? 0.0;
+                $bestMonths        = $results[0]['months'] ?? 0;
                 foreach ($results as $i => &$result) {
                     $result['rank']              = $i + 1;
                     $result['cost_of_deviation'] = $result['total_interest'] - $bestTotalInterest;
+                    $result['ranking_heuristic'] = self::RANKING_HEURISTIC;
+                    $result['trade_offs']        = [
+                        'interest_diff' => $result['total_interest'] - $bestTotalInterest,
+                        'months_diff'   => $result['months'] - $bestMonths,
+                    ];
                 }
 
                 return $results;


### PR DESCRIPTION
## Summary
- track ranking heuristic and trade-offs in simulation plans
- surface heuristic metadata in debt simulation API responses

## Testing
- `php -l app/Services/DebtSimulation/SimulationService.php`
- `php -l app/Modules/AI/Simulations/DebtSimulationService.php`
- `php -l app/Api/V1/Controllers/Simulations/DebtController.php`
- `composer unit-test`


------
https://chatgpt.com/codex/tasks/task_e_688ec1080fc48326b9efc9e7c4130f68