### PR TITLE
docs: document user_group_id security

### DIFF
--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -11,7 +11,7 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
 ```json
 {
   "user_id": 1,
-  "group_id": 1,
+  "user_group_id": 1,
   "monthly_budget": 500,
   "max_options": 2,
   "accounts": [
@@ -24,7 +24,7 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
 ### Request fields
 
 - `user_id` – Owning user identifier.
-- `group_id` – User group identifier.
+- `user_group_id` – User group identifier. Validated with [ValidatesUserGroupTrait](../app/Support/Http/Api/ValidatesUserGroupTrait.php) to ensure the authenticated user belongs to the group, preventing cross-group data exposure.
 - `monthly_budget` – Amount available each month for debt repayment.
 - `max_options` – Maximum number of strategies to return.
 - `accounts` – Array of debts to simulate. Each account contains:


### PR DESCRIPTION
## Summary
- clarify user_group_id request parameter in debt simulation API docs
- link to ValidatesUserGroupTrait and note group membership security

## Testing
- No tests run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_688fd067afec83269ef48a2d598dd1f8