### PR TITLE
feat: optimize Monte Carlo simulation

### DIFF
--- a/app/Modules/AI/Goals/MonteCarloSimulationService.php
+++ b/app/Modules/AI/Goals/MonteCarloSimulationService.php
@@ -37,8 +37,8 @@ class MonteCarloSimulationService
     private function randomNormal(float $mean = 0.0, float $stdev = 1.0): float
     {
         // Box-Muller transform
-        $u1 = mt_rand() / mt_getrandmax();
-        $u2 = mt_rand() / mt_getrandmax();
+        $u1 = (mt_rand() + 1) / (mt_getrandmax() + 1);
+        $u2 = (mt_rand() + 1) / (mt_getrandmax() + 1);
         $z0 = \sqrt(-2.0 * \log($u1)) * \cos(2 * M_PI * $u2);
 
         return $z0 * $stdev + $mean;
@@ -51,22 +51,22 @@ class MonteCarloSimulationService
      */
     public function project(float $initial, float $mean, float $stdev, int $years, int $runs = 1000): array
     {
-        $steps      = $years * 12; // monthly steps
-        $projection = [];
+        $steps        = $years * 12; // monthly steps
+        $projection   = [];
+        $values       = array_fill(0, $runs, $initial);
+        $monthlyMean  = $mean / 12;
+        $monthlyStdev = $stdev / \sqrt(12);
 
         for ($step = 1; $step <= $steps; ++$step) {
-            $total        = 0.0;
+            $total = 0.0;
             for ($run = 0; $run < $runs; ++$run) {
-                $value = $initial;
-                for ($i = 0; $i < $step; ++$i) {
-                    $value *= 1 + $this->randomNormal($mean / 12, $stdev / \sqrt(12));
-                }
-                $total += $value;
+                $values[$run] *= 1 + $this->randomNormal($monthlyMean, $monthlyStdev);
+                $total       += $values[$run];
             }
-            $average      = $total / $runs;
+
             $projection[] = [
                 'month'  => $step,
-                'amount' => $average,
+                'amount' => $total / $runs,
             ];
         }
 


### PR DESCRIPTION
## Summary
- optimize Monte Carlo simulation by iteratively accumulating monthly values
- ensure Box-Muller transform inputs avoid 0 to prevent invalid logs

## Testing
- `APP_ENV=testing APP_KEY=base64:E3DxylhNy5QCTczAdG50QnOLx7rK4yWHGQiXkmo1x/I= composer unit-test`
- `APP_ENV=testing APP_KEY=base64:E3DxylhNy5QCTczAdG50QnOLx7rK4yWHGQiXkmo1x/I= vendor/bin/phpstan analyse app/Modules/AI/Goals/MonteCarloSimulationService.php --memory-limit=1G`


------
https://chatgpt.com/codex/tasks/task_e_688fd0670a508326b2313d6765f96c85