### PR TITLE
Expose plan arrays in debt simulations

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -197,6 +197,7 @@ class DebtSimulationService
         }
 
         return [
+            'plan'              => $schedule,
             'schedule'          => $schedule,
             'total_interest'    => $totalInterest,
             'months'            => $month,

--- a/app/Services/DebtSimulation/SimulationService.php
+++ b/app/Services/DebtSimulation/SimulationService.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * SimulationService.php
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * @deprecated Use \FireflyIII\Modules\AI\Simulations\DebtSimulationService instead.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Services\DebtSimulation;
+
+use FireflyIII\Modules\AI\Simulations\DebtSimulationService as AISimulationService;
+
+/**
+ * @deprecated Use \FireflyIII\Modules\AI\Simulations\DebtSimulationService instead.
+ */
+class SimulationService extends AISimulationService
+{
+}
+

--- a/tests/unit/DebtSimulationTest.php
+++ b/tests/unit/DebtSimulationTest.php
@@ -56,6 +56,8 @@ final class DebtSimulationTest extends TestCase
 
         self::assertCount(6, $mapped['avalanche']['schedule']);
         self::assertCount(6, $mapped['snowball']['schedule']);
+        self::assertSame($mapped['avalanche']['schedule'], $mapped['avalanche']['plan']);
+        self::assertSame($mapped['snowball']['schedule'], $mapped['snowball']['plan']);
     }
 
     public function testRanksAvalancheAheadOfSnowballWithMetrics(): void


### PR DESCRIPTION
## Summary
- add `plan` alias to each debt payoff schedule
- provide deprecated SimulationService wrapper to avoid duplication
- ensure tests cover new plan output

## Testing
- `composer run-script unit-test`
- `vendor/bin/phpstan analyse --memory-limit=512M --no-progress app/Modules/AI/Simulations/DebtSimulationService.php app/Services/DebtSimulation/SimulationService.php tests/unit/DebtSimulationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6894a7dfc1f48326b67369b871ff94cc