### PR TITLE
Add UUID validation and cache isolation tests for debt simulations

### DIFF
--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -10,8 +10,11 @@ use Illuminate\Support\Facades\Cache;
 use FireflyIII\Http\Middleware\Authenticate;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 use FireflyIII\Http\Middleware\OpaMiddleware;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Validator;
 use Mockery;
 use Tests\integration\TestCase as IntegrationTestCase;
+use function Safe\putenv;
 
 final class DebtSimulationApiTest extends IntegrationTestCase
 {
@@ -24,12 +27,27 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         config(['auth.defaults.guard' => 'web']);
 
         $accounts   = [
-            ['id' => 1, 'balance' => 100.0, 'rate' => 5.0],
-            ['id' => 2, 'balance' => 200.0, 'rate' => 3.0],
+            [
+                'id'               => 1,
+                'account_id'       => 1,
+                'balance'          => 100.0,
+                'rate'             => 5.0,
+                'apr'              => 5.0,
+                'min_payment'      => 0.0,
+                'minimum_payment'  => 0.0,
+            ],
+            [
+                'id'               => 2,
+                'account_id'       => 2,
+                'balance'          => 200.0,
+                'rate'             => 3.0,
+                'apr'              => 3.0,
+                'min_payment'      => 0.0,
+                'minimum_payment'  => 0.0,
+            ],
         ];
         $budget     = 50.0;
         $maxOptions = 2;
-        $hash       = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
 
         $user1 = User::create(['email' => 'user1@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user1);
@@ -37,8 +55,8 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $this->be($user1);
 
         $payload1 = [
-            'user_id'        => (string) $user1->id,
-            'group_id'       => null === $user1->user_group_id ? null : (string) $user1->user_group_id,
+            'user_id'        => '1f111111-1111-1111-1111-111111111111',
+            'group_id'       => null,
             'accounts'       => $accounts,
             'monthly_budget' => $budget,
             'max_options'    => $maxOptions,
@@ -46,7 +64,36 @@ final class DebtSimulationApiTest extends IntegrationTestCase
 
         $response1  = $this->postJson('/api/v1/simulations/debt', $payload1)->assertOk();
         $response1b = $this->postJson('/api/v1/simulations/debt', $payload1)->assertOk();
-        $this->assertSame($response1->json(), $response1b->json());
+        self::assertSame($response1->json('data.proposed_actions'), $response1b->json('data.proposed_actions'));
+
+        $response1->assertJsonStructure([
+            'data' => [
+                'proposed_actions' => [
+                    [
+                        'rank',
+                        'is_optimal',
+                        'plan' => [
+                            'strategy',
+                            'schedule',
+                            'monthly_cash_flow',
+                        ],
+                        'metrics' => [
+                            'interest_saved',
+                            'time_to_payoff_months',
+                        ],
+                        'cost_of_deviation' => [
+                            'amount' => ['value', 'currency'],
+                            'time'   => ['value', 'unit'],
+                        ],
+                        'meta' => ['ranking_heuristic'],
+                    ],
+                ],
+            ],
+            'meta' => ['analysis_id', 'ranking_heuristic'],
+        ]);
+        self::assertTrue(Str::isUuid($response1->json('meta.analysis_id')));
+        self::assertNotEmpty($response1->json('data.proposed_actions.0.plan.schedule'));
+        self::assertArrayHasKey('cost_of_deviation', $response1->json('data.proposed_actions.0'));
 
         $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user2);
@@ -54,8 +101,8 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $this->be($user2);
 
         $payload2 = [
-            'user_id'        => (string) $user2->id,
-            'group_id'       => null === $user2->user_group_id ? null : (string) $user2->user_group_id,
+            'user_id'        => '2f222222-2222-2222-2222-222222222222',
+            'group_id'       => null,
             'accounts'       => $accounts,
             'monthly_budget' => $budget,
             'max_options'    => $maxOptions,
@@ -63,6 +110,40 @@ final class DebtSimulationApiTest extends IntegrationTestCase
 
         $response2  = $this->postJson('/api/v1/simulations/debt', $payload2)->assertOk();
         $response2b = $this->postJson('/api/v1/simulations/debt', $payload2)->assertOk();
-        $this->assertSame($response2->json(), $response2b->json());
+        self::assertSame($response2->json('data.proposed_actions'), $response2b->json('data.proposed_actions'));
+    }
+
+    public function testUuidValidationAndNullableGroupId(): void
+    {
+        $accounts = [
+            [
+                'id'               => 1,
+                'account_id'       => 1,
+                'balance'          => 100.0,
+                'rate'             => 5.0,
+                'apr'              => 5.0,
+                'min_payment'      => 0.0,
+                'minimum_payment'  => 0.0,
+            ],
+        ];
+
+        $invalid = [
+            'user_id'        => 'not-a-uuid',
+            'group_id'       => 'also-not-a-uuid',
+            'accounts'       => $accounts,
+            'monthly_budget' => 50.0,
+            'max_options'    => 2,
+        ];
+        $rules = (new \FireflyIII\Api\V1\Requests\Simulations\DebtRequest())->rules();
+        $validator = Validator::make($invalid, $rules);
+        self::assertTrue($validator->fails());
+        self::assertArrayHasKey('user_id', $validator->errors()->toArray());
+        self::assertArrayHasKey('group_id', $validator->errors()->toArray());
+
+        $valid = $invalid;
+        $valid['user_id']  = (string) Str::uuid();
+        $valid['group_id'] = null;
+        $validator = Validator::make($valid, $rules);
+        self::assertFalse($validator->fails());
     }
 }

--- a/tests/unit/DebtSimulationTest.php
+++ b/tests/unit/DebtSimulationTest.php
@@ -35,6 +35,14 @@ final class DebtSimulationTest extends TestCase
 
         self::assertCount(2, $plans);
 
+        foreach ($plans as $plan) {
+            self::assertArrayHasKey('schedule', $plan);
+            self::assertIsArray($plan['schedule']);
+            self::assertArrayHasKey('cost_of_deviation', $plan);
+            self::assertArrayHasKey('currency', $plan['cost_of_deviation']);
+            self::assertArrayHasKey('time_months', $plan['cost_of_deviation']);
+        }
+
         $mapped = [];
         foreach ($plans as $plan) {
             $mapped[$plan['strategy']] = $plan;
@@ -72,6 +80,13 @@ final class DebtSimulationTest extends TestCase
         $budget = 300.0;
 
         $plans = $service->simulate((string) $user->id, '1', $accounts, $budget, 2);
+        foreach ($plans as $plan) {
+            self::assertArrayHasKey('schedule', $plan);
+            self::assertIsArray($plan['schedule']);
+            self::assertArrayHasKey('cost_of_deviation', $plan);
+            self::assertArrayHasKey('currency', $plan['cost_of_deviation']);
+            self::assertArrayHasKey('time_months', $plan['cost_of_deviation']);
+        }
         $mapped = [];
         foreach ($plans as $plan) {
             $mapped[$plan['strategy']] = $plan;

--- a/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
@@ -28,7 +28,8 @@ final class DebtSimulationServiceCachingTest extends TestCase
         Cache::flush();
 
         $service  = new DebtSimulationService();
-        $userId   = '1';
+        $userIdA  = '1';
+        $userIdB  = '01';
         $groupId  = '1';
         $accounts = [
             ['id' => 1, 'balance' => 100.0, 'rate' => 5.0],
@@ -36,15 +37,20 @@ final class DebtSimulationServiceCachingTest extends TestCase
         $budget     = 50.0;
         $maxOptions = 2;
 
-        $service->simulate($userId, $groupId, $accounts, $budget, $maxOptions);
+        $service->simulate($userIdA, $groupId, $accounts, $budget, $maxOptions);
 
-        $hash     = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
-        $cacheKey = sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupId, $hash);
+        $hash       = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
+        $cacheKeyA  = sprintf('u:%s:g:%s:debt-sim-%s', $userIdA, $groupId, $hash);
+        self::assertTrue(Cache::has($cacheKeyA));
 
-        self::assertTrue(Cache::has($cacheKey));
+        $service->simulate($userIdB, $groupId, $accounts, $budget, $maxOptions);
+        $cacheKeyB = sprintf('u:%s:g:%s:debt-sim-%s', $userIdB, $groupId, $hash);
+        self::assertTrue(Cache::has($cacheKeyB));
+        self::assertNotEquals($cacheKeyA, $cacheKeyB);
 
-        UserScopedCache::flush($userId, $groupId);
+        UserScopedCache::flush($userIdA, $groupId);
 
-        self::assertFalse(Cache::has($cacheKey));
+        self::assertFalse(Cache::has($cacheKeyA));
+        self::assertTrue(Cache::has($cacheKeyB));
     }
 }


### PR DESCRIPTION
## Summary
- verify debt simulation API includes analysis metadata and validates UUID fields
- assert simulation plans expose schedules and deviation costs
- ensure user-scoped cache differentiates string user IDs

## Testing
- `vendor/bin/phpstan analyse --memory-limit=512M tests/Feature/DebtSimulationApiTest.php tests/unit/DebtSimulationTest.php tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php`
- `vendor/bin/phpunit tests/Feature/DebtSimulationApiTest.php tests/unit/DebtSimulationTest.php tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6894b8d4a4788326b45e97d115401faa