### PR TITLE
feat: validate accounts for debt simulation

### DIFF
--- a/app/Api/V1/Requests/Simulations/DebtRequest.php
+++ b/app/Api/V1/Requests/Simulations/DebtRequest.php
@@ -28,6 +28,9 @@ namespace FireflyIII\Api\V1\Requests\Simulations;
 use FireflyIII\Support\Request\ChecksLogin;
 use FireflyIII\Support\Request\ConvertsDataTypes;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use FireflyIII\Repositories\Account\AccountRepositoryInterface;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Class DebtRequest
@@ -72,5 +75,37 @@ class DebtRequest extends FormRequest
             'monthly_budget'               => 'required|numeric|min:0',
             'max_options'                  => 'required|integer|min:1',
         ];
+    }
+
+    /**
+     * Configure the validator instance with special rules after the basic validation rules.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(
+            function (Validator $validator): void {
+                $data = $validator->getData();
+                if (!array_key_exists('accounts', $data) || !is_array($data['accounts'])) {
+                    return;
+                }
+
+                /** @var AccountRepositoryInterface $repository */
+                $repository = app(AccountRepositoryInterface::class);
+                $repository->setUser(auth()->user());
+
+                foreach ($data['accounts'] as $index => $array) {
+                    $accountId = (int) ($array['account_id'] ?? 0);
+                    if (null === $repository->find($accountId)) {
+                        $validator->errors()->add(
+                            sprintf('accounts.%d.account_id', $index),
+                            trans('validation.belongs_user_or_user_group')
+                        );
+                    }
+                }
+            }
+        );
+        if ($validator->fails()) {
+            Log::channel('audit')->error(sprintf('Validation errors in %s', self::class), $validator->errors()->toArray());
+        }
     }
 }

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use FireflyIII\Console\Commands\Correction\CreatesGroupMemberships;
+use FireflyIII\Enums\AccountTypeEnum;
+use FireflyIII\Models\Account;
+use FireflyIII\Models\AccountType;
 use FireflyIII\User;
 use Illuminate\Support\Facades\Cache;
 use FireflyIII\Http\Middleware\Authenticate;
@@ -26,10 +29,34 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
         config(['auth.defaults.guard' => 'web']);
 
-        $accounts   = [
+        $budget     = 50.0;
+        $maxOptions = 2;
+
+        $user1 = User::create(['email' => 'user1@example.com', 'password' => 'secret']);
+        CreatesGroupMemberships::createGroupMembership($user1);
+        $user1->refresh();
+
+        $type      = AccountType::where('type', AccountTypeEnum::DEBT->value)->first();
+        $account1  = Account::create([
+            'user_id'         => $user1->id,
+            'user_group_id'   => $user1->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Debt 1',
+            'active'          => true,
+        ]);
+        $account2  = Account::create([
+            'user_id'         => $user1->id,
+            'user_group_id'   => $user1->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Debt 2',
+            'active'          => true,
+        ]);
+        $this->be($user1);
+
+        $accounts1 = [
             [
-                'id'               => 1,
-                'account_id'       => 1,
+                'id'               => $account1->id,
+                'account_id'       => $account1->id,
                 'balance'          => 100.0,
                 'rate'             => 5.0,
                 'apr'              => 5.0,
@@ -37,8 +64,8 @@ final class DebtSimulationApiTest extends IntegrationTestCase
                 'minimum_payment'  => 0.0,
             ],
             [
-                'id'               => 2,
-                'account_id'       => 2,
+                'id'               => $account2->id,
+                'account_id'       => $account2->id,
                 'balance'          => 200.0,
                 'rate'             => 3.0,
                 'apr'              => 3.0,
@@ -46,18 +73,11 @@ final class DebtSimulationApiTest extends IntegrationTestCase
                 'minimum_payment'  => 0.0,
             ],
         ];
-        $budget     = 50.0;
-        $maxOptions = 2;
-
-        $user1 = User::create(['email' => 'user1@example.com', 'password' => 'secret']);
-        CreatesGroupMemberships::createGroupMembership($user1);
-        $user1->refresh();
-        $this->be($user1);
 
         $payload1 = [
             'user_id'        => '1f111111-1111-1111-1111-111111111111',
             'group_id'       => null,
-            'accounts'       => $accounts,
+            'accounts'       => $accounts1,
             'monthly_budget' => $budget,
             'max_options'    => $maxOptions,
         ];
@@ -98,12 +118,48 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user2);
         $user2->refresh();
+
+        $account3 = Account::create([
+            'user_id'         => $user2->id,
+            'user_group_id'   => $user2->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Debt 3',
+            'active'          => true,
+        ]);
+        $account4 = Account::create([
+            'user_id'         => $user2->id,
+            'user_group_id'   => $user2->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Debt 4',
+            'active'          => true,
+        ]);
         $this->be($user2);
+
+        $accounts2 = [
+            [
+                'id'               => $account3->id,
+                'account_id'       => $account3->id,
+                'balance'          => 100.0,
+                'rate'             => 5.0,
+                'apr'              => 5.0,
+                'min_payment'      => 0.0,
+                'minimum_payment'  => 0.0,
+            ],
+            [
+                'id'               => $account4->id,
+                'account_id'       => $account4->id,
+                'balance'          => 200.0,
+                'rate'             => 3.0,
+                'apr'              => 3.0,
+                'min_payment'      => 0.0,
+                'minimum_payment'  => 0.0,
+            ],
+        ];
 
         $payload2 = [
             'user_id'        => '2f222222-2222-2222-2222-222222222222',
             'group_id'       => null,
-            'accounts'       => $accounts,
+            'accounts'       => $accounts2,
             'monthly_budget' => $budget,
             'max_options'    => $maxOptions,
         ];
@@ -145,5 +201,52 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $valid['group_id'] = null;
         $validator = Validator::make($valid, $rules);
         self::assertFalse($validator->fails());
+    }
+
+    public function testUnauthorizedAccountAccess(): void
+    {
+        Cache::setDefaultDriver('file');
+        putenv('CACHE_DRIVER=file');
+        Cache::flush();
+        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
+        config(['auth.defaults.guard' => 'web']);
+
+        $user1 = User::create(['email' => 'user1@example.com', 'password' => 'secret']);
+        CreatesGroupMemberships::createGroupMembership($user1);
+        $user1->refresh();
+        $this->be($user1);
+
+        $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
+        CreatesGroupMemberships::createGroupMembership($user2);
+        $user2->refresh();
+
+        $type     = AccountType::where('type', AccountTypeEnum::DEBT->value)->first();
+        $foreign  = Account::create([
+            'user_id'         => $user2->id,
+            'user_group_id'   => $user2->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Foreign debt',
+            'active'          => true,
+        ]);
+
+        $payload = [
+            'user_id'        => '1f111111-1111-1111-1111-111111111111',
+            'group_id'       => null,
+            'accounts'       => [[
+                'id'               => $foreign->id,
+                'account_id'       => $foreign->id,
+                'balance'          => 100.0,
+                'rate'             => 5.0,
+                'apr'              => 5.0,
+                'min_payment'      => 0.0,
+                'minimum_payment'  => 0.0,
+            ]],
+            'monthly_budget' => 50.0,
+            'max_options'    => 2,
+        ];
+
+        $this->postJson('/api/v1/simulations/debt', $payload)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['accounts.0.account_id']);
     }
 }


### PR DESCRIPTION
## Summary
- ensure debt simulation accounts belong to the authenticated user
- cover unauthorized account usage with new feature test

## Testing
- `vendor/bin/phpunit tests/Feature/DebtSimulationApiTest.php`
- `vendor/bin/phpstan analyse app/Api/V1/Requests/Simulations/DebtRequest.php tests/Feature/DebtSimulationApiTest.php --no-progress --memory-limit=512M`


------
https://chatgpt.com/codex/tasks/task_e_6894cbd7bfa48326bbf9507f23ea9487