### PR TITLE
Expose total interest paid in debt simulations

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -77,6 +77,7 @@ class DebtController extends Controller
                     'metrics' => [
                         'interest_saved'        => (float) $plan['interest_saved'],
                         'time_to_payoff_months' => (int) $plan['time_to_payoff_months'],
+                        'total_interest_paid'   => (float) $plan['total_interest'],
                     ],
                     'cost_of_deviation' => [
                         'amount' => [

--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -93,6 +93,7 @@ class DebtSimulationService
                 foreach ($plans as $i => &$plan) {
                     $plan['rank']                  = $i + 1;
                     $plan['is_optimal']            = 0 === $i;
+                    $plan['total_interest']        = (float) $plan['total_interest'];
                     $plan['interest_saved']        = $worstInterest - $plan['total_interest'];
                     $plan['time_to_payoff_months'] = $plan['months'];
                     $plan['cost_of_deviation']     = [
@@ -101,6 +102,7 @@ class DebtSimulationService
                     ];
                     $plan['ranking_heuristic']     = self::RANKING_HEURISTIC;
                 }
+                unset($plan);
 
                 return $plans;
             }

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -60,7 +60,8 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
         },
         "metrics": {
           "interest_saved": 61.88,
-          "time_to_payoff_months": 34
+          "time_to_payoff_months": 34,
+          "total_interest_paid": 516.09
         },
         "cost_of_deviation": {
           "amount": {"value": 0, "currency": "USD"},
@@ -91,7 +92,8 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
         },
         "metrics": {
           "interest_saved": 0,
-          "time_to_payoff_months": 36
+          "time_to_payoff_months": 36,
+          "total_interest_paid": 577.97
         },
         "cost_of_deviation": {
           "amount": {"value": 61.88, "currency": "USD"},
@@ -123,6 +125,7 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
   - `metrics` – Aggregated plan results:
     - `interest_saved` – Interest saved compared to the worst plan.
     - `time_to_payoff_months` – Number of months to clear all debts.
+    - `total_interest_paid` – Total interest paid over the lifetime of the plan.
   - `cost_of_deviation` – Extra cost versus the optimal plan:
     - `amount` – Additional interest with `value` and `currency`.
     - `time` – Additional duration with `value` and `unit`.


### PR DESCRIPTION
## Summary
- Preserve total interest for each payoff plan in debt simulations
- Return `metrics.total_interest_paid` from debt simulation API
- Document `total_interest_paid` in debt simulation response

## Testing
- `vendor/bin/phpstan analyse --no-progress` *(fails: No application encryption key has been specified.)*
- `composer unit-test`


------
https://chatgpt.com/codex/tasks/task_e_6894cbd6bb88832686526d9362fa10af