### PR TITLE
Use APR for debt simulations

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -46,8 +46,8 @@ class DebtSimulationService
      * @param string      $userId     The owning user identifier.
      * @param string|null $groupId    The user group identifier.
      * @param array $accounts   Array of accounts. Each entry must contain
-     *                          `id`, `balance` and `rate` (APR percentage) and
-     *                          may contain `name` and `min_payment`.
+     *                          `account_id`, `balance` and `apr` (APR percentage)
+     *                          and may contain `id`, `name` and `min_payment`.
      * @param float $budget     Total monthly amount available for debt payments.
      * @param int   $maxOptions Maximum number of plans to return.
      *
@@ -66,9 +66,9 @@ class DebtSimulationService
                 // Normalize account data for simulation service.
                 $debts = array_map(static function (array $account): array {
                     return [
-                        'name'        => (string) ($account['name'] ?? $account['id']),
+                        'name'        => (string) ($account['name'] ?? $account['id'] ?? $account['account_id']),
                         'balance'     => (float) $account['balance'],
-                        'rate'        => (float) $account['rate'] / 100,
+                        'rate'        => (float) $account['apr'] / 100,
                         'min_payment' => (float) ($account['min_payment'] ?? $account['minimum_payment'] ?? 0.0),
                     ];
                 }, $accounts);
@@ -199,7 +199,6 @@ class DebtSimulationService
         }
 
         return [
-            'plan'              => $schedule,
             'schedule'          => $schedule,
             'total_interest'    => $totalInterest,
             'months'            => $month,

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -55,19 +55,15 @@ final class DebtSimulationApiTest extends IntegrationTestCase
 
         $accounts1 = [
             [
-                'id'               => $account1->id,
                 'account_id'       => $account1->id,
                 'balance'          => 100.0,
-                'rate'             => 5.0,
                 'apr'              => 5.0,
                 'min_payment'      => 0.0,
                 'minimum_payment'  => 0.0,
             ],
             [
-                'id'               => $account2->id,
                 'account_id'       => $account2->id,
                 'balance'          => 200.0,
-                'rate'             => 3.0,
                 'apr'              => 3.0,
                 'min_payment'      => 0.0,
                 'minimum_payment'  => 0.0,
@@ -114,6 +110,10 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         self::assertTrue(Str::isUuid($response1->json('meta.analysis_id')));
         self::assertNotEmpty($response1->json('data.proposed_actions.0.plan.schedule'));
         self::assertArrayHasKey('cost_of_deviation', $response1->json('data.proposed_actions.0'));
+        self::assertArrayHasKey(
+            (string) $account1->id,
+            $response1->json('data.proposed_actions.0.plan.schedule.0.payments')
+        );
 
         $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user2);
@@ -137,19 +137,15 @@ final class DebtSimulationApiTest extends IntegrationTestCase
 
         $accounts2 = [
             [
-                'id'               => $account3->id,
                 'account_id'       => $account3->id,
                 'balance'          => 100.0,
-                'rate'             => 5.0,
                 'apr'              => 5.0,
                 'min_payment'      => 0.0,
                 'minimum_payment'  => 0.0,
             ],
             [
-                'id'               => $account4->id,
                 'account_id'       => $account4->id,
                 'balance'          => 200.0,
-                'rate'             => 3.0,
                 'apr'              => 3.0,
                 'min_payment'      => 0.0,
                 'minimum_payment'  => 0.0,
@@ -173,10 +169,8 @@ final class DebtSimulationApiTest extends IntegrationTestCase
     {
         $accounts = [
             [
-                'id'               => 1,
                 'account_id'       => 1,
                 'balance'          => 100.0,
-                'rate'             => 5.0,
                 'apr'              => 5.0,
                 'min_payment'      => 0.0,
                 'minimum_payment'  => 0.0,
@@ -233,10 +227,8 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             'user_id'        => '1f111111-1111-1111-1111-111111111111',
             'group_id'       => null,
             'accounts'       => [[
-                'id'               => $foreign->id,
                 'account_id'       => $foreign->id,
                 'balance'          => 100.0,
-                'rate'             => 5.0,
                 'apr'              => 5.0,
                 'min_payment'      => 0.0,
                 'minimum_payment'  => 0.0,

--- a/tests/unit/DebtSimulationTest.php
+++ b/tests/unit/DebtSimulationTest.php
@@ -27,7 +27,7 @@ final class DebtSimulationTest extends TestCase
         $service = new DebtSimulationService();
 
         $accounts = [
-            ['id' => 1, 'name' => 'Loan', 'balance' => 1000.0, 'rate' => 10.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
         ];
         $budget = 200.0;
 
@@ -41,6 +41,7 @@ final class DebtSimulationTest extends TestCase
             self::assertArrayHasKey('cost_of_deviation', $plan);
             self::assertArrayHasKey('currency', $plan['cost_of_deviation']);
             self::assertArrayHasKey('time_months', $plan['cost_of_deviation']);
+            self::assertArrayHasKey('1', $plan['schedule'][0]['payments']);
         }
 
         $mapped = [];
@@ -64,8 +65,6 @@ final class DebtSimulationTest extends TestCase
 
         self::assertCount(6, $mapped['avalanche']['schedule']);
         self::assertCount(6, $mapped['snowball']['schedule']);
-        self::assertSame($mapped['avalanche']['schedule'], $mapped['avalanche']['plan']);
-        self::assertSame($mapped['snowball']['schedule'], $mapped['snowball']['plan']);
     }
 
     public function testRanksAvalancheAheadOfSnowballWithMetrics(): void
@@ -74,8 +73,8 @@ final class DebtSimulationTest extends TestCase
         $service = new DebtSimulationService();
 
         $accounts = [
-            ['id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'rate' => 10.0, 'min_payment' => 0.0],
-            ['id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'rate' => 5.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
+            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
         ];
         $budget = 300.0;
 

--- a/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
@@ -32,7 +32,7 @@ final class DebtSimulationServiceCachingTest extends TestCase
         $userIdB  = '01';
         $groupId  = '1';
         $accounts = [
-            ['id' => 1, 'balance' => 100.0, 'rate' => 5.0],
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 5.0],
         ];
         $budget     = 50.0;
         $maxOptions = 2;


### PR DESCRIPTION
## Summary
- Read APR from account data and convert to decimal rate
- Remove unused `plan` return value and rely on `account_id` for names

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G app/Modules/AI/Simulations/DebtSimulationService.php tests/unit/DebtSimulationTest.php tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php tests/Feature/DebtSimulationApiTest.php`
- `vendor/bin/phpunit tests/unit/DebtSimulationTest.php tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php tests/Feature/DebtSimulationApiTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68964d369c388326b229981bfab65825