### PR TITLE
Simplify debt simulation response

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -62,32 +62,25 @@ class DebtController extends Controller
             (int) $data['max_options']
         );
 
-        $analysisId = (string) Str::uuid();
-        $currency   = config('firefly.default_currency');
+        $analysisId      = (string) Str::uuid();
         $proposedActions = array_map(
-            static function (array $plan) use ($currency): array {
+            static function (array $plan): array {
                 return [
                     'rank'       => $plan['rank'],
                     'is_optimal' => $plan['is_optimal'],
                     'plan'       => [
-                        'strategy'          => $plan['strategy'],
-                        'schedule'          => $plan['schedule'],
-                        'monthly_cash_flow' => $plan['monthly_cash_flow'],
+                        'strategy' => $plan['strategy'],
+                        'schedule' => $plan['schedule'],
                     ],
                     'metrics' => [
                         'interest_saved'        => (float) $plan['interest_saved'],
                         'time_to_payoff_months' => (int) $plan['time_to_payoff_months'],
                         'total_interest_paid'   => (float) $plan['total_interest'],
+                        'monthly_cash_flow'     => $plan['monthly_cash_flow'],
                     ],
                     'cost_of_deviation' => [
-                        'amount' => [
-                            'value'    => (float) $plan['cost_of_deviation']['currency'],
-                            'currency' => $currency,
-                        ],
-                        'time' => [
-                            'value' => (int) $plan['cost_of_deviation']['time_months'],
-                            'unit'  => 'months',
-                        ],
+                        'currency'    => (float) $plan['cost_of_deviation']['currency'],
+                        'time_months' => (int) $plan['cost_of_deviation']['time_months'],
                     ],
                     'meta' => [
                         'ranking_heuristic' => $plan['ranking_heuristic'],
@@ -98,13 +91,8 @@ class DebtController extends Controller
         );
 
         return response()->json([
-            'data' => [
-                'proposed_actions' => $proposedActions,
-            ],
-            'meta' => [
-                'analysis_id'      => $analysisId,
-                'ranking_heuristic' => DebtSimulationService::RANKING_HEURISTIC,
-            ],
+            'analysis_id'      => $analysisId,
+            'proposed_actions' => $proposedActions,
         ]);
     }
 }

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -37,78 +37,73 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
 
 ```json
 {
-  "data": {
-    "proposed_actions": [
-      {
-        "rank": 1,
-        "is_optimal": true,
-        "plan": {
-          "strategy": "avalanche",
-          "schedule": [
-            {
-              "month": 1,
-              "payments": {"10": 500, "11": 0},
-              "balances": {"10": 4000, "11": 1200},
-              "interest": 60,
-              "payment": 500,
-              "cash_flow": 0
-            }
-          ],
-          "monthly_cash_flow": [
-            {"month": 1, "cash_flow": 0}
-          ]
-        },
-        "metrics": {
-          "interest_saved": 61.88,
-          "time_to_payoff_months": 34,
-          "total_interest_paid": 516.09
-        },
-        "cost_of_deviation": {
-          "amount": {"value": 0, "currency": "USD"},
-          "time": {"value": 0, "unit": "months"}
-        },
-        "meta": {
-          "ranking_heuristic": "interest_then_months"
-        }
+  "analysis_id": "b4383ee0-1e6b-4b4e-8f4e-01fb9c93b5b4",
+  "proposed_actions": [
+    {
+      "rank": 1,
+      "is_optimal": true,
+      "plan": {
+        "strategy": "avalanche",
+        "schedule": [
+          {
+            "month": 1,
+            "payments": {"10": 500, "11": 0},
+            "balances": {"10": 4000, "11": 1200},
+            "interest": 60,
+            "payment": 500,
+            "cash_flow": 0
+          }
+        ]
       },
-      {
-        "rank": 2,
-        "is_optimal": false,
-        "plan": {
-          "strategy": "snowball",
-          "schedule": [
-            {
-              "month": 1,
-              "payments": {"10": 475, "11": 25},
-              "balances": {"10": 4025, "11": 1175},
-              "interest": 57.19,
-              "payment": 500,
-              "cash_flow": 0
-            }
-          ],
-          "monthly_cash_flow": [
-            {"month": 1, "cash_flow": 0}
-          ]
-        },
-        "metrics": {
-          "interest_saved": 0,
-          "time_to_payoff_months": 36,
-          "total_interest_paid": 577.97
-        },
-        "cost_of_deviation": {
-          "amount": {"value": 61.88, "currency": "USD"},
-          "time": {"value": 2, "unit": "months"}
-        },
-        "meta": {
-          "ranking_heuristic": "interest_then_months"
-        }
+      "metrics": {
+        "interest_saved": 61.88,
+        "time_to_payoff_months": 34,
+        "total_interest_paid": 516.09,
+        "monthly_cash_flow": [
+          {"month": 1, "cash_flow": 0}
+        ]
+      },
+      "cost_of_deviation": {
+        "currency": 0,
+        "time_months": 0
+      },
+      "meta": {
+        "ranking_heuristic": "interest_then_months"
       }
-    ]
-  },
-  "meta": {
-    "analysis_id": "b4383ee0-1e6b-4b4e-8f4e-01fb9c93b5b4",
-    "ranking_heuristic": "interest_then_months"
-  }
+    },
+    {
+      "rank": 2,
+      "is_optimal": false,
+      "plan": {
+        "strategy": "snowball",
+        "schedule": [
+          {
+            "month": 1,
+            "payments": {"10": 475, "11": 25},
+            "balances": {"10": 4025, "11": 1175},
+            "interest": 57.19,
+            "payment": 500,
+            "cash_flow": 0
+          }
+        ]
+      },
+      "metrics": {
+        "interest_saved": 0,
+        "time_to_payoff_months": 36,
+        "total_interest_paid": 577.97,
+        "monthly_cash_flow": [
+          {"month": 1, "cash_flow": 0}
+        ]
+      },
+      "cost_of_deviation": {
+        "currency": 61.88,
+        "time_months": 2
+      },
+      "meta": {
+        "ranking_heuristic": "interest_then_months"
+      }
+    }
+  ]
 }
 ```
 
@@ -121,14 +116,14 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
   - `plan` – Detailed strategy output:
     - `strategy` – Name of the heuristic applied (`avalanche` or `snowball`).
     - `schedule` – Monthly breakdown of payments, balances, interest and cash flow.
-    - `monthly_cash_flow` – Remaining budget for each month.
   - `metrics` – Aggregated plan results:
     - `interest_saved` – Interest saved compared to the worst plan.
     - `time_to_payoff_months` – Number of months to clear all debts.
     - `total_interest_paid` – Total interest paid over the lifetime of the plan.
+    - `monthly_cash_flow` – Remaining budget for each month.
   - `cost_of_deviation` – Extra cost versus the optimal plan:
-    - `amount` – Additional interest with `value` and `currency`.
-    - `time` – Additional duration with `value` and `unit`.
+    - `currency` – Additional interest compared to the optimal plan.
+    - `time_months` – Additional duration compared to the optimal plan in months.
 
 ## Heuristics
 

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -80,39 +80,35 @@ final class DebtSimulationApiTest extends IntegrationTestCase
 
         $response1  = $this->postJson('/api/v1/simulations/debt', $payload1)->assertOk();
         $response1b = $this->postJson('/api/v1/simulations/debt', $payload1)->assertOk();
-        self::assertSame($response1->json('data.proposed_actions'), $response1b->json('data.proposed_actions'));
+        self::assertSame($response1->json('proposed_actions'), $response1b->json('proposed_actions'));
 
         $response1->assertJsonStructure([
-            'data' => [
-                'proposed_actions' => [
-                    [
-                        'rank',
-                        'is_optimal',
-                        'plan' => [
-                            'strategy',
-                            'schedule',
-                            'monthly_cash_flow',
-                        ],
-                        'metrics' => [
-                            'interest_saved',
-                            'time_to_payoff_months',
-                        ],
-                        'cost_of_deviation' => [
-                            'amount' => ['value', 'currency'],
-                            'time'   => ['value', 'unit'],
-                        ],
-                        'meta' => ['ranking_heuristic'],
+            'analysis_id',
+            'proposed_actions' => [
+                [
+                    'rank',
+                    'is_optimal',
+                    'plan' => [
+                        'strategy',
+                        'schedule',
                     ],
+                    'metrics' => [
+                        'interest_saved',
+                        'time_to_payoff_months',
+                        'total_interest_paid',
+                        'monthly_cash_flow',
+                    ],
+                    'cost_of_deviation' => ['currency', 'time_months'],
+                    'meta' => ['ranking_heuristic'],
                 ],
             ],
-            'meta' => ['analysis_id', 'ranking_heuristic'],
         ]);
-        self::assertTrue(Str::isUuid($response1->json('meta.analysis_id')));
-        self::assertNotEmpty($response1->json('data.proposed_actions.0.plan.schedule'));
-        self::assertArrayHasKey('cost_of_deviation', $response1->json('data.proposed_actions.0'));
+        self::assertTrue(Str::isUuid($response1->json('analysis_id')));
+        self::assertNotEmpty($response1->json('proposed_actions.0.plan.schedule'));
+        self::assertArrayHasKey('cost_of_deviation', $response1->json('proposed_actions.0'));
         self::assertArrayHasKey(
             (string) $account1->id,
-            $response1->json('data.proposed_actions.0.plan.schedule.0.payments')
+            $response1->json('proposed_actions.0.plan.schedule.0.payments')
         );
 
         $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
@@ -162,7 +158,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
 
         $response2  = $this->postJson('/api/v1/simulations/debt', $payload2)->assertOk();
         $response2b = $this->postJson('/api/v1/simulations/debt', $payload2)->assertOk();
-        self::assertSame($response2->json('data.proposed_actions'), $response2b->json('data.proposed_actions'));
+        self::assertSame($response2->json('proposed_actions'), $response2b->json('proposed_actions'));
     }
 
     public function testUuidValidationAndNullableGroupId(): void


### PR DESCRIPTION
## Summary
- Return analysis_id and proposed_actions at the root of debt simulation response
- Flatten cost_of_deviation and move monthly_cash_flow to metrics
- Adjust API docs and tests for new schema

## Testing
- `vendor/bin/phpstan analyse app/Api/V1/Controllers/Simulations/DebtController.php --no-progress`
- `composer unit-test`
- `composer integration-test` *(fails: Invalid key supplied in AboutControllerTest)*

------
https://chatgpt.com/codex/tasks/task_e_689654aaf53c832686cd7dad3c86be8f