### PR TITLE
Validate group membership in debt request

### DIFF
--- a/app/Api/V1/Requests/Simulations/DebtRequest.php
+++ b/app/Api/V1/Requests/Simulations/DebtRequest.php
@@ -27,6 +27,7 @@ namespace FireflyIII\Api\V1\Requests\Simulations;
 
 use FireflyIII\Support\Request\ChecksLogin;
 use FireflyIII\Support\Request\ConvertsDataTypes;
+use FireflyIII\Support\Http\Api\ValidatesUserGroupTrait;
 use FireflyIII\Models\Account;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
@@ -43,6 +44,7 @@ class DebtRequest extends FormRequest
 {
     use ChecksLogin;
     use ConvertsDataTypes;
+    use ValidatesUserGroupTrait;
 
     /**
      * Extract validated data with proper types.
@@ -95,6 +97,18 @@ class DebtRequest extends FormRequest
 
                 if ((string) request('user_id') !== (string) auth()->id()) {
                     $validator->errors()->add('user_id', trans('validation.in'));
+                }
+
+                if (array_key_exists('group_id', $data) && null !== $data['group_id']) {
+                    $groupId     = (string) $data['group_id'];
+                    $membership  = auth()->user()->groupMemberships->first(
+                        static fn ($membership) => (string) $membership->userGroup->uuid === $groupId
+                    );
+                    if (null === $membership) {
+                        $validator->errors()->add('group_id', trans('validation.belongs_user_or_user_group'));
+                    } else {
+                        $this->userGroup = $membership->userGroup;
+                    }
                 }
 
                 if (!array_key_exists('accounts', $data) || !is_array($data['accounts'])) {


### PR DESCRIPTION
## Summary
- import and apply ValidatesUserGroupTrait in debt simulation request
- validate submitted group_id against user's memberships

## Testing
- `composer unit-test`
- `APP_KEY='base64:7GB/RfNzoQRg1ZG4LMO11j9o3RtM8Lw226NaESrmEU8=' vendor/bin/phpstan analyse app/Api/V1/Requests/Simulations/DebtRequest.php --memory-limit=512M`


------
https://chatgpt.com/codex/tasks/task_e_6896bc4f9db48326b59dcc4e1a77f6d6