### PR TITLE
test: validate group id ownership

### DIFF
--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -231,4 +231,49 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             ->assertStatus(422)
             ->assertJsonValidationErrors(['accounts.0.account_id']);
     }
+
+    public function testRejectsGroupIdFromDifferentUserGroup(): void
+    {
+        // Configure environment and disable auth middleware
+        Cache::setDefaultDriver('file');
+        putenv('CACHE_DRIVER=file');
+        Cache::flush();
+        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
+        config(['auth.defaults.guard' => 'web']);
+
+        $user1 = User::create(['email' => 'user1@example.com', 'password' => 'secret']);
+        CreatesGroupMemberships::createGroupMembership($user1);
+        $user1->refresh();
+        $this->be($user1);
+
+        $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
+        CreatesGroupMemberships::createGroupMembership($user2);
+        $user2->refresh();
+
+        $type     = AccountType::where('type', AccountTypeEnum::DEBT->value)->first();
+        $account1 = Account::create([
+            'user_id'         => $user1->id,
+            'user_group_id'   => $user1->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Debt 1',
+            'active'          => true,
+        ]);
+
+        $payload = [
+            'user_id'        => (string) $user1->id,
+            'group_id'       => (string) $user2->user_group_id,
+            'accounts'       => [[
+                'account_id'       => $account1->id,
+                'balance'          => 100.0,
+                'apr'              => 5.0,
+                'minimum_payment'  => 0.0,
+            ]],
+            'monthly_budget' => 50.0,
+            'max_options'    => 2,
+        ];
+
+        $this->postJson('/api/v1/simulations/debt', $payload)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['group_id']);
+    }
 }


### PR DESCRIPTION
## Summary
- add test ensuring debt simulation rejects group_id from a different user group
- clarify scenario setup in test

## Testing
- `APP_KEY=base64:zcELB6oiqSDhD4375+DhvKueBxEHVQ6RA/iRyBH6k3M= ./vendor/bin/phpstan analyse -c .ci/phpstan.neon --memory-limit=1G --error-format=table --no-progress` (fails: Found 496 errors)
- `composer integration-test` (fails: Invalid key supplied)


------
https://chatgpt.com/codex/tasks/task_e_6896bc501b688326b669a0c9c4f818c8