### PR TITLE
Add plan ranking metadata for debt simulations

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -100,7 +100,20 @@ class DebtSimulationService
                         'currency'    => $plan['total_interest'] - $bestInterest,
                         'time_months' => $plan['months'] - $bestMonths,
                     ];
-                    $plan['ranking_heuristic']     = self::RANKING_HEURISTIC;
+
+                    $tradeoffString = $plan['is_optimal']
+                        ? 'no tradeoffs'
+                        : sprintf(
+                            '%.2f extra interest and %d more months',
+                            $plan['cost_of_deviation']['currency'],
+                            $plan['cost_of_deviation']['time_months']
+                        );
+
+                    $plan['meta'] = [
+                        'ranking_heuristic' => self::RANKING_HEURISTIC,
+                        'ranking_reason'    => $plan['is_optimal'] ? 'minimizes interest' : 'higher cost or duration',
+                        'tradeoffs'         => $tradeoffString,
+                    ];
                 }
                 unset($plan);
 

--- a/tests/unit/DebtSimulationTest.php
+++ b/tests/unit/DebtSimulationTest.php
@@ -108,6 +108,11 @@ final class DebtSimulationTest extends TestCase
         self::assertEquals(6, $mapped['avalanche']['time_to_payoff_months']);
         self::assertEquals(6, $mapped['snowball']['time_to_payoff_months']);
 
-        self::assertSame(DebtSimulationService::RANKING_HEURISTIC, $mapped['avalanche']['ranking_heuristic']);
+        self::assertSame(
+            DebtSimulationService::RANKING_HEURISTIC,
+            $mapped['avalanche']['meta']['ranking_heuristic']
+        );
+        self::assertIsString($mapped['avalanche']['meta']['ranking_reason']);
+        self::assertIsString($mapped['avalanche']['meta']['tradeoffs']);
     }
 }


### PR DESCRIPTION
## Summary
- enrich debt payoff plans with ranking metadata including ranking reason and tradeoffs
- move ranking heuristic into plan metadata and cover with tests

## Testing
- `./vendor/bin/phpstan analyse -c .ci/phpstan.neon --no-progress --memory-limit=1G`
- `composer unit-test`

------
https://chatgpt.com/codex/tasks/task_e_68978290459083268896a3d021b4649f