### PR TITLE
Handle empty strategies and clamp debt simulation budget

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -69,6 +69,10 @@ class DebtSimulationService
      */
     public function simulate(string $userId, ?string $groupId, array $accounts, float $budget, int $maxOptions = 2): array
     {
+        if (0 === count($this->strategies)) {
+            return [];
+        }
+
         $hash     = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
         $cacheKey = 'debt-sim-' . $hash;
 
@@ -189,6 +193,8 @@ class DebtSimulationService
             }
             unset($debt);
 
+            $remainingBudget = max($remainingBudget, 0.0);
+
             // Allocate any extra budget to targeted debt(s).
             while ($remainingBudget > 0 && $this->hasBalance($debts)) {
                 $targetKey = $strategy->selectTargetDebt($debts);
@@ -206,7 +212,7 @@ class DebtSimulationService
                 unset($target);
             }
 
-            $totalPayment      = $monthlyBudget - $remainingBudget;
+            $totalPayment      = array_sum($paymentPlan);
             $totalInterest    += $interestThisMonth;
             $cashFlowTimeline[] = ['month' => $month, 'cash_flow' => $remainingBudget];
 

--- a/tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\unit\Modules\AI;
+
+use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use Illuminate\Support\Facades\Cache;
+use Tests\integration\TestCase;
+
+/**
+ * @group unit-test
+ * @group ai
+ */
+final class DebtSimulationServiceBudgetTest extends TestCase
+{
+    public function testClampsNegativeCashFlow(): void
+    {
+        Cache::flush();
+
+        $service  = new DebtSimulationService();
+        $userId   = 'user';
+        $groupId  = 'group';
+        $accounts = [
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 0.0, 'min_payment' => 60.0],
+            ['account_id' => 2, 'balance' => 100.0, 'apr' => 0.0, 'min_payment' => 60.0],
+        ];
+
+        $plans = $service->simulate($userId, $groupId, $accounts, 50.0, 1);
+
+        foreach ($plans[0]['schedule'] as $month) {
+            self::assertGreaterThanOrEqual(0.0, $month['cash_flow']);
+        }
+    }
+
+    public function testReturnsEmptyWhenNoStrategies(): void
+    {
+        Cache::flush();
+
+        $service  = new DebtSimulationService([]);
+        $userId   = 'user';
+        $groupId  = 'group';
+        $accounts = [
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 5.0],
+        ];
+
+        $plans = $service->simulate($userId, $groupId, $accounts, 50.0, 1);
+
+        self::assertSame([], $plans);
+    }
+}


### PR DESCRIPTION
## Summary
- Guard against missing debt payoff strategies by returning an empty result
- Clamp remaining budget to zero after minimum payments and compute total payments from actual plan
- Add unit tests for low-budget cash flow and empty strategy scenarios

## Testing
- `composer unit-test`
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa vendor/bin/phpstan analyse --memory-limit=1G app/Modules/AI/Simulations/DebtSimulationService.php tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689802063ba08326b70d78c134db25ce