### PR TITLE
Implement proportional extra payment distribution

### DIFF
--- a/app/Modules/AI/Simulations/Strategies/BalancedStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/BalancedStrategy.php
@@ -4,8 +4,22 @@ declare(strict_types=1);
 
 namespace FireflyIII\Modules\AI\Simulations\Strategies;
 
+/**
+ * Distributes extra payments proportionally across outstanding debts.
+ *
+ * The implementation uses a smooth weighted round-robin algorithm so that
+ * debts with larger balances receive extra payments more frequently than
+ * those with smaller balances.
+ */
 class BalancedStrategy implements StrategyInterface
 {
+    /**
+     * Internal weights used for the smooth weighted round-robin algorithm.
+     *
+     * @var array<int, float>
+     */
+    private array $currentWeights = [];
+
     public function getName(): string
     {
         return 'balanced';
@@ -13,12 +27,32 @@ class BalancedStrategy implements StrategyInterface
 
     public function selectTargetDebt(array $debts): ?int
     {
+        $activeBalances = [];
         foreach ($debts as $idx => $debt) {
             if ($debt['balance'] > 0.0) {
-                return $idx;
+                $activeBalances[$idx]       = $debt['balance'];
+                $this->currentWeights[$idx] = $this->currentWeights[$idx] ?? 0.0;
+            } else {
+                unset($this->currentWeights[$idx]);
             }
         }
 
-        return null;
+        if ([] === $activeBalances) {
+            return null;
+        }
+
+        $totalWeight = array_sum($activeBalances);
+        $selected    = null;
+
+        foreach ($activeBalances as $idx => $balance) {
+            $this->currentWeights[$idx] += $balance;
+            if (null === $selected || $this->currentWeights[$idx] > $this->currentWeights[$selected]) {
+                $selected = $idx;
+            }
+        }
+
+        $this->currentWeights[$selected] -= $totalWeight;
+
+        return $selected;
     }
 }


### PR DESCRIPTION
## Summary
- Distribute extra debt payments using a smooth weighted round-robin strategy
- Document balanced strategy's proportional payment behavior

## Testing
- `APP_KEY=base64:0123456789012345678901234567890123456789012 ./vendor/bin/phpstan analyse app/Modules/AI/Simulations/Strategies/BalancedStrategy.php`
- `composer unit-test`


------
https://chatgpt.com/codex/tasks/task_e_689baaf670708326bf87e1771d2dac3d