### PR TITLE
Ensure debt simulations rank all strategies

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -95,14 +95,13 @@ class DebtSimulationService
                 foreach ($this->strategies as $strategy) {
                     $plan    = $this->generateSchedule($debts, $budget, $strategy);
                     $plans[] = array_merge(['strategy' => $strategy->getName()], $plan);
-                    if (count($plans) >= $maxOptions) {
-                        break;
-                    }
                 }
 
                 usort($plans, static function (array $a, array $b): int {
                     return [$a['total_interest'], $a['months']] <=> [$b['total_interest'], $b['months']];
                 });
+
+                $plans = array_slice($plans, 0, $maxOptions);
 
                 $bestInterest  = $plans[0]['total_interest'] ?? 0.0;
                 $bestMonths    = $plans[0]['months'] ?? 0;

--- a/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Tests\unit\Modules\AI;
 
 use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use FireflyIII\Modules\AI\Simulations\Strategies\AvalancheStrategy;
+use FireflyIII\Modules\AI\Simulations\Strategies\BalancedStrategy;
+use FireflyIII\Modules\AI\Simulations\Strategies\SnowballStrategy;
 use Illuminate\Support\Facades\Cache;
 use Tests\integration\TestCase;
 
@@ -46,5 +49,30 @@ final class DebtSimulationServiceRankingTest extends TestCase
             self::assertIsString($plan['meta']['ranking_reason']);
             self::assertIsString($plan['meta']['tradeoffs']);
         }
+    }
+
+    public function testBestPlansReturnedRegardlessOfStrategyOrder(): void
+    {
+        Cache::flush();
+
+        $user       = $this->createAuthenticatedUser();
+        $accounts   = [
+            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
+            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
+        ];
+
+        $strategies = [SnowballStrategy::class, BalancedStrategy::class, AvalancheStrategy::class];
+
+        $serviceA = new DebtSimulationService($strategies);
+        $plansA   = $serviceA->simulate((string) $user->id, '1', $accounts, 300.0, 2);
+
+        $serviceB = new DebtSimulationService(array_reverse($strategies));
+        $plansB   = $serviceB->simulate((string) $user->id, '1', $accounts, 300.0, 2);
+
+        $strategiesA = array_column($plansA, 'strategy');
+        $strategiesB = array_column($plansB, 'strategy');
+
+        self::assertSame($strategiesA, $strategiesB);
+        self::assertSame('avalanche', $strategiesA[0]);
     }
 }


### PR DESCRIPTION
## Summary
- Generate payoff plans for all strategies before ranking
- Return best-ranked plans even if optimal strategy is listed last
- Add regression test for deterministic ranking across strategy orderings

## Testing
- `vendor/bin/phpstan analyse app/Modules/AI/Simulations/DebtSimulationService.php tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php --no-progress --memory-limit=1G`
- `composer unit-test`


------
https://chatgpt.com/codex/tasks/task_e_689c949a30408326940f1b4006c76684