### PR TITLE
Validate debt simulation budget against minimum payments

### DIFF
--- a/app/Api/V1/Requests/Simulations/DebtRequest.php
+++ b/app/Api/V1/Requests/Simulations/DebtRequest.php
@@ -131,6 +131,16 @@ class DebtRequest extends FormRequest
                         );
                     }
                 }
+
+                $minimumPayments = array_reduce(
+                    $data['accounts'],
+                    static fn (float $carry, array $account): float => $carry + (float) ($account['minimum_payment'] ?? 0.0),
+                    0.0
+                );
+
+                if ((float) ($data['monthly_budget'] ?? 0.0) < $minimumPayments) {
+                    $validator->errors()->add('monthly_budget', trans('validation.insufficient_budget'));
+                }
             }
         );
         if ($validator->fails()) {

--- a/resources/lang/en_US/validation.php
+++ b/resources/lang/en_US/validation.php
@@ -67,6 +67,7 @@ return [
     'invalid_selection'                => 'Your selection is invalid.',
     'belongs_user'                     => 'This value is linked to an object that does not seem to exist.',
     'belongs_user_or_user_group'       => 'This value is linked to an object that does not seem to exist in your current financial administration.',
+    'insufficient_budget'              => 'The monthly budget must be at least the sum of all minimum payments.',
     'no_access_group'                  => 'The user has no access to this administration.',
     'no_accepted_roles_defined'        => 'No access roles have been defined for this endpoint, access denied.',
     'at_least_one_transaction'         => 'Need at least one transaction.',

--- a/tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\unit\Modules\AI;
 
+use FireflyIII\Api\V1\Requests\Simulations\DebtRequest;
+use FireflyIII\Enums\AccountTypeEnum;
+use FireflyIII\Models\Account;
+use FireflyIII\Models\AccountType;
 use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use FireflyIII\Console\Commands\Correction\CreatesGroupMemberships;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Validator;
 use Tests\integration\TestCase;
 
 /**
@@ -47,5 +53,61 @@ final class DebtSimulationServiceBudgetTest extends TestCase
         $plans = $service->simulate($userId, $groupId, $accounts, 50.0, 1);
 
         self::assertSame([], $plans);
+    }
+
+    public function testValidationFailsWhenBudgetBelowMinimums(): void
+    {
+        Cache::flush();
+
+        $user = $this->createAuthenticatedUser();
+        CreatesGroupMemberships::createGroupMembership($user);
+        $user->refresh();
+        $this->be($user);
+
+        $type     = AccountType::where('type', AccountTypeEnum::DEBT->value)->first();
+        $account1 = Account::create([
+            'user_id'         => $user->id,
+            'user_group_id'   => $user->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Debt 1',
+            'active'          => true,
+        ]);
+        $account2 = Account::create([
+            'user_id'         => $user->id,
+            'user_group_id'   => $user->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Debt 2',
+            'active'          => true,
+        ]);
+
+        $payload = [
+            'user_id'        => (string) $user->uuid,
+            'group_id'       => null,
+            'accounts'       => [
+                [
+                    'account_id'      => (string) $account1->uuid,
+                    'balance'         => 100.0,
+                    'apr'             => 5.0,
+                    'minimum_payment' => 60.0,
+                ],
+                [
+                    'account_id'      => (string) $account2->uuid,
+                    'balance'         => 100.0,
+                    'apr'             => 3.0,
+                    'minimum_payment' => 70.0,
+                ],
+            ],
+            'monthly_budget' => 100.0,
+            'max_options'    => 1,
+        ];
+
+        request()->replace($payload);
+
+        $rules     = (new DebtRequest())->rules();
+        $validator = Validator::make($payload, $rules);
+        (new DebtRequest())->withValidator($validator);
+
+        self::assertTrue($validator->fails());
+        self::assertArrayHasKey('monthly_budget', $validator->errors()->toArray());
     }
 }


### PR DESCRIPTION
## Summary
- reject debt simulation requests when monthly budget is less than sum of minimum payments
- add translation for insufficient budget
- test for budget below minimum payments validation

## Testing
- `composer unit-test`
- `vendor/bin/phpstan analyse app tests --no-progress --memory-limit=1G` *(fails: Found 531 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cd802a7148326965b603819e90d68