### PR TITLE
Expose strategy descriptions in debt simulation output

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -94,7 +94,13 @@ class DebtSimulationService
                 $plans = [];
                 foreach ($this->strategies as $strategy) {
                     $plan    = $this->generateSchedule($debts, $budget, $strategy);
-                    $plans[] = array_merge(['strategy' => $strategy->getName()], $plan);
+                    $plans[] = array_merge(
+                        [
+                            'strategy' => $strategy->getName(),
+                            'meta'     => ['strategy_explanation' => $strategy->getDescription()],
+                        ],
+                        $plan
+                    );
                 }
 
                 usort($plans, static function (array $a, array $b): int {
@@ -126,11 +132,14 @@ class DebtSimulationService
                             $plan['cost_of_deviation']['time_months']
                         );
 
-                    $plan['meta'] = [
-                        'ranking_heuristic' => self::RANKING_HEURISTIC,
-                        'ranking_reason'    => $plan['is_optimal'] ? 'minimizes interest' : 'higher cost or duration',
-                        'tradeoffs'         => $tradeoffString,
-                    ];
+                    $plan['meta'] = array_merge(
+                        $plan['meta'],
+                        [
+                            'ranking_heuristic' => self::RANKING_HEURISTIC,
+                            'ranking_reason'    => $plan['is_optimal'] ? 'minimizes interest' : 'higher cost or duration',
+                            'tradeoffs'         => $tradeoffString,
+                        ]
+                    );
                 }
                 unset($plan);
 

--- a/app/Modules/AI/Simulations/Strategies/AvalancheStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/AvalancheStrategy.php
@@ -11,6 +11,11 @@ class AvalancheStrategy implements StrategyInterface
         return 'avalanche';
     }
 
+    public function getDescription(): string
+    {
+        return 'Pays extra toward the debt with the highest interest rate first.';
+    }
+
     public function selectTargetDebt(array $debts): ?int
     {
         $indices     = array_keys($debts);

--- a/app/Modules/AI/Simulations/Strategies/BalancedStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/BalancedStrategy.php
@@ -25,6 +25,11 @@ class BalancedStrategy implements StrategyInterface
         return 'balanced';
     }
 
+    public function getDescription(): string
+    {
+        return 'Distributes extra payments proportionally based on each debt\'s remaining balance.';
+    }
+
     public function selectTargetDebt(array $debts): ?int
     {
         $activeBalances = [];

--- a/app/Modules/AI/Simulations/Strategies/SnowballStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/SnowballStrategy.php
@@ -11,6 +11,11 @@ class SnowballStrategy implements StrategyInterface
         return 'snowball';
     }
 
+    public function getDescription(): string
+    {
+        return 'Pays extra toward the debt with the smallest balance first to build momentum.';
+    }
+
     public function selectTargetDebt(array $debts): ?int
     {
         $indices     = array_keys($debts);

--- a/app/Modules/AI/Simulations/Strategies/StrategyInterface.php
+++ b/app/Modules/AI/Simulations/Strategies/StrategyInterface.php
@@ -9,6 +9,11 @@ interface StrategyInterface
     public function getName(): string;
 
     /**
+     * Human-readable explanation of how the strategy allocates extra payments.
+     */
+    public function getDescription(): string;
+
+    /**
      * Select the index of the debt that should receive extra payments.
      *
      * @param array<int, array<string, float>> $debts

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -85,8 +85,8 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
         "time_months": 0
       },
       "meta": {
-        "ranking_heuristic": "interest_then_months"
-
+        "ranking_heuristic": "interest_then_months",
+        "strategy_explanation": "Pays extra toward the debt with the highest interest rate first."
       }
     },
     {
@@ -120,8 +120,8 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
         "time_months": 2
       },
       "meta": {
-        "ranking_heuristic": "interest_then_months"
-
+        "ranking_heuristic": "interest_then_months",
+        "strategy_explanation": "Pays extra toward the debt with the smallest balance first to build momentum."
       }
     }
   ]
@@ -146,6 +146,11 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
   - `cost_of_deviation` – Extra cost versus the optimal plan:
     - `currency` – Additional interest compared to the optimal plan.
     - `time_months` – Additional duration compared to the optimal plan in months.
+  - `meta` – Additional information about the plan:
+    - `strategy_explanation` – Description of how the payoff strategy works.
+    - `ranking_heuristic` – Ranking algorithm applied to the plans.
+    - `ranking_reason` – Explanation of why the plan received its rank.
+    - `tradeoffs` – Summary of extra cost and time versus the optimal plan.
 
 ## Heuristics
 


### PR DESCRIPTION
## Summary
- extend `StrategyInterface` with `getDescription()` and implement in each strategy
- include strategy explanations in `DebtSimulationService` response metadata
- document `meta.strategy_explanation` in debt simulation API docs

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpstan analyse app/Modules/AI/Simulations --memory-limit=1G`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= composer unit-test`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= composer integration-test` *(fails: Invalid key supplied)*

------
https://chatgpt.com/codex/tasks/task_e_689d00c57a08832683188258bd7afbb5