### PR TITLE
Expose strategy explanation in debt simulation API

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -91,6 +91,7 @@ class DebtController extends Controller
                     'ranking_heuristic' => $plan['meta']['ranking_heuristic'],
                     'ranking_reason'    => $plan['meta']['ranking_reason'] ?? $plan['meta']['ranking_heuristic'],
                     'tradeoffs'         => $plan['meta']['tradeoffs'] ?? $plan['cost_of_deviation'],
+                    'strategy_explanation' => $plan['meta']['strategy_explanation'],
                 ];
 
                 return $result;

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -88,7 +88,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         ];
 
         $payload1 = [
-            'user_id'        => (string) $user1->uuid,
+            'user_id'        => $user1->uuid,
             'group_id'       => null,
             'accounts'       => $accounts1,
             'monthly_budget' => $budget,
@@ -112,7 +112,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
                         'total_interest_paid',
                         'monthly_cash_flow',
                     ],
-                    'meta' => ['ranking_heuristic', 'tradeoffs', 'ranking_reason'],
+                    'meta' => ['ranking_heuristic', 'tradeoffs', 'ranking_reason', 'strategy_explanation'],
                 ],
             ],
         ]);
@@ -129,11 +129,15 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             }
             self::assertArrayHasKey('ranking_reason', $action['meta']);
             self::assertIsString($action['meta']['tradeoffs']);
+            self::assertArrayHasKey('strategy_explanation', $action['meta']);
+            self::assertIsString($action['meta']['strategy_explanation']);
         }
         self::assertArrayHasKey('ranking_heuristic', $response1->json('proposed_actions.0.meta'));
         self::assertArrayHasKey('tradeoffs', $response1->json('proposed_actions.0.meta'));
         self::assertArrayHasKey('ranking_reason', $response1->json('proposed_actions.0.meta'));
+        self::assertArrayHasKey('strategy_explanation', $response1->json('proposed_actions.0.meta'));
         self::assertIsString($response1->json('proposed_actions.0.meta.tradeoffs'));
+        self::assertIsString($response1->json('proposed_actions.0.meta.strategy_explanation'));
 
         $this->postJson('/api/v1/simulations/debt', array_merge($payload1, ['user_id' => (string) Str::uuid()]))
             ->assertStatus(401);
@@ -181,7 +185,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         ];
 
         $payload2 = [
-            'user_id'        => (string) $user2->uuid,
+            'user_id'        => $user2->uuid,
             'group_id'       => null,
             'accounts'       => $accounts2,
             'monthly_budget' => $budget,


### PR DESCRIPTION
## Summary
- include `strategy_explanation` in debt simulation responses
- assert presence and type of `strategy_explanation` in debt simulation API tests

## Testing
- `vendor/bin/phpstan analyse app/Api/V1/Controllers/Simulations/DebtController.php tests/Feature/DebtSimulationApiTest.php --memory-limit=1G`
- `vendor/bin/phpunit tests/Feature/DebtSimulationApiTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d3b3e9e608326baadf66f19591709