### PR TITLE
Detect non-converging debt simulations

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -38,6 +38,7 @@ use FireflyIII\Support\Cache\UserScopedCache;
 class DebtSimulationService
 {
     public const RANKING_HEURISTIC = 'interest_then_months';
+    public const MAX_MONTHS = 600;
 
     /** @var StrategyInterface[] */
     private array $strategies;
@@ -111,7 +112,8 @@ class DebtSimulationService
 
                 $bestInterest  = $plans[0]['total_interest'] ?? 0.0;
                 $bestMonths    = $plans[0]['months'] ?? 0;
-                $worstInterest = max(array_column($plans, 'total_interest'));
+                $interestList  = array_column($plans, 'total_interest');
+                $worstInterest = $interestList !== [] ? max($interestList) : 0.0;
 
                 foreach ($plans as $i => &$plan) {
                     $plan['rank']                  = $i + 1;
@@ -171,10 +173,21 @@ class DebtSimulationService
         $totalInterest     = 0.0;
         $month             = 0;
         $cashFlowTimeline  = [];
+        $nonConverging     = false;
 
         while ($this->hasBalance($debts)) {
+            if ($month >= self::MAX_MONTHS) {
+                $nonConverging = true;
+                break;
+            }
+
             ++$month;
             $interestThisMonth = 0.0;
+            $balanceBefore     = 0.0;
+            foreach ($debts as $debt) {
+                $balanceBefore += max($debt['balance'], 0.0);
+            }
+            unset($debt);
             foreach ($debts as &$debt) {
                 if ($debt['balance'] <= 0) {
                     continue;
@@ -204,7 +217,7 @@ class DebtSimulationService
             $remainingBudget = max($remainingBudget, 0.0);
 
             // Allocate any extra budget to targeted debt(s).
-            while ($remainingBudget > 0 && $this->hasBalance($debts)) {
+            while ($remainingBudget > 0 && $this->hasBalance($debts)) { // @phpstan-ignore-line booleanAnd.rightAlwaysTrue
                 $targetKey = $strategy->selectTargetDebt($debts);
                 if (null === $targetKey) {
                     break;
@@ -225,8 +238,11 @@ class DebtSimulationService
             $cashFlowTimeline[] = ['month' => $month, 'cash_flow' => $remainingBudget];
 
             $balanceSnapshot = [];
+            $balanceAfter    = 0.0;
             foreach ($debts as $debt) {
-                $balanceSnapshot[$debt['name']] = max($debt['balance'], 0.0);
+                $currentBalance                   = max($debt['balance'], 0.0);
+                $balanceSnapshot[$debt['name']]   = $currentBalance;
+                $balanceAfter                    += $currentBalance;
             }
 
             $schedule[] = [
@@ -237,6 +253,11 @@ class DebtSimulationService
                 'payment'   => $totalPayment,
                 'cash_flow' => $remainingBudget,
             ];
+
+            if ($balanceAfter > $balanceBefore) {
+                $nonConverging = true;
+                break;
+            }
         }
 
         return [
@@ -244,6 +265,7 @@ class DebtSimulationService
             'total_interest'    => $totalInterest,
             'months'            => $month,
             'monthly_cash_flow' => $cashFlowTimeline,
+            'status'            => $nonConverging ? 'non_converging' : 'ok',
         ];
     }
 

--- a/tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\unit\Modules\AI;
+
+use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use Illuminate\Support\Facades\Cache;
+use Tests\integration\TestCase;
+
+/**
+ * @group unit-test
+ * @group ai
+ */
+final class DebtSimulationNonConvergingTest extends TestCase
+{
+    public function testDetectsGrowingBalance(): void
+    {
+        Cache::flush();
+        $service = new DebtSimulationService();
+
+        $accounts = [
+            ['account_id' => 1, 'balance' => 1000.0, 'apr' => 120.0, 'min_payment' => 0.0],
+        ];
+        $budget = 50.0;
+
+        $plans = $service->simulate('user', 'group', $accounts, $budget, 1);
+
+        self::assertSame('non_converging', $plans[0]['status']);
+        self::assertLessThanOrEqual(DebtSimulationService::MAX_MONTHS, $plans[0]['months']);
+    }
+}


### PR DESCRIPTION
## Summary
- guard against non-converging debt payoff simulations by flagging growing balances and capping iterations
- add unit test for high-interest scenario to ensure simulations stop and report non-converging status

## Testing
- `APP_KEY=base64:/1CqNKrWM081ierJPTP0flKHMvAC/+/VK7YxZW9RNig= vendor/bin/phpstan analyse -c .ci/phpstan.neon --no-progress --memory-limit=1G app/Modules/AI/Simulations/DebtSimulationService.php tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php`
- `APP_KEY=base64:/1CqNKrWM081ierJPTP0flKHMvAC/+/VK7YxZW9RNig= composer unit-test`


------
https://chatgpt.com/codex/tasks/task_e_689d3b3f47788326a4b18d042344a9d9