### PR TITLE
Add reset capability to debt payoff strategies

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -175,6 +175,8 @@ class DebtSimulationService
         $cashFlowTimeline  = [];
         $nonConverging     = false;
 
+        $strategy->reset();
+
         while ($this->hasBalance($debts)) {
             if ($month >= self::MAX_MONTHS) {
                 $nonConverging = true;
@@ -217,7 +219,7 @@ class DebtSimulationService
             $remainingBudget = max($remainingBudget, 0.0);
 
             // Allocate any extra budget to targeted debt(s).
-            while ($remainingBudget > 0 && $this->hasBalance($debts)) { // @phpstan-ignore-line booleanAnd.rightAlwaysTrue
+            while ($remainingBudget > 0 && $this->hasBalance($debts)) {
                 $targetKey = $strategy->selectTargetDebt($debts);
                 if (null === $targetKey) {
                     break;

--- a/app/Modules/AI/Simulations/Strategies/AvalancheStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/AvalancheStrategy.php
@@ -16,6 +16,10 @@ class AvalancheStrategy implements StrategyInterface
         return 'Pays extra toward the debt with the highest interest rate first.';
     }
 
+    public function reset(): void
+    {
+    }
+
     public function selectTargetDebt(array $debts): ?int
     {
         $indices     = array_keys($debts);

--- a/app/Modules/AI/Simulations/Strategies/BalancedStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/BalancedStrategy.php
@@ -20,6 +20,11 @@ class BalancedStrategy implements StrategyInterface
      */
     private array $currentWeights = [];
 
+    public function reset(): void
+    {
+        $this->currentWeights = [];
+    }
+
     public function getName(): string
     {
         return 'balanced';

--- a/app/Modules/AI/Simulations/Strategies/SnowballStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/SnowballStrategy.php
@@ -16,6 +16,10 @@ class SnowballStrategy implements StrategyInterface
         return 'Pays extra toward the debt with the smallest balance first to build momentum.';
     }
 
+    public function reset(): void
+    {
+    }
+
     public function selectTargetDebt(array $debts): ?int
     {
         $indices     = array_keys($debts);

--- a/app/Modules/AI/Simulations/Strategies/StrategyInterface.php
+++ b/app/Modules/AI/Simulations/Strategies/StrategyInterface.php
@@ -13,6 +13,9 @@ interface StrategyInterface
      */
     public function getDescription(): string;
 
+    /** Reset any internal state before simulating a new schedule. */
+    public function reset(): void;
+
     /**
      * Select the index of the debt that should receive extra payments.
      *


### PR DESCRIPTION
## Summary
- add reset hooks to simulation strategies
- clear weights in `BalancedStrategy` before reuse
- invoke `reset()` in debt payoff schedule generation

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpstan analyse app/Modules/AI/Simulations --no-progress --memory-limit=1G`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php -d memory_limit=1G vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_689dfc29c1b88326b4f9a1f8bb4191c5