### PR TITLE
Optimize debt account lookup

### DIFF
--- a/app/Api/V1/Requests/Simulations/DebtRequest.php
+++ b/app/Api/V1/Requests/Simulations/DebtRequest.php
@@ -119,12 +119,21 @@ class DebtRequest extends FormRequest
                 $repository = app(AccountRepositoryInterface::class);
                 $repository->setUser(auth()->user());
 
-                foreach ($data['accounts'] as $index => $array) {
-                    $uuid    = (string) ($array['account_id'] ?? '');
-                    $account = Account::where('uuid', $uuid)->first();
-                    $accountId = (int) (($account instanceof Account) ? $account->id : 0);
+                $uuids = [];
+                foreach ($data['accounts'] as $array) {
+                    $uuids[] = (string) ($array['account_id'] ?? '');
+                }
 
-                    if (null === $repository->find($accountId)) {
+                $uuidMap      = Account::query()->whereIn('uuid', $uuids)->pluck('id', 'uuid');
+                $authorized   = array_flip(
+                    $repository->getAccountsById($uuidMap->values()->all())->pluck('id')->all()
+                );
+
+                foreach ($data['accounts'] as $index => $array) {
+                    $uuid      = (string) ($array['account_id'] ?? '');
+                    $accountId = (int) ($uuidMap[$uuid] ?? 0);
+
+                    if (0 === $accountId || !isset($authorized[$accountId])) {
                         $validator->errors()->add(
                             sprintf('accounts.%d.account_id', $index),
                             trans('validation.belongs_user_or_user_group')


### PR DESCRIPTION
## Summary
- Batch-fetch accounts in DebtRequest to avoid per-account queries
- Validate requested debt accounts by comparing UUID mapping and repository results

## Testing
- `vendor/bin/phpstan analyze app/Api/V1/Requests/Simulations/DebtRequest.php` *(fails: No such file or directory)*
- `composer unit-test` *(fails: Could not open input file: vendor/bin/phpunit)*
- `composer install` *(fails: missing ext-sodium)*


------
https://chatgpt.com/codex/tasks/task_e_689e04986d348326a73930a546c5eb9b