### PR TITLE
feat: add cache TTL config

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -76,6 +76,7 @@ class DebtSimulationService
 
         $hash     = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
         $cacheKey = 'debt-sim-' . $hash;
+        $ttl      = (int) config('ai.debt_simulation_cache_ttl', 3600);
 
         return UserScopedCache::remember(
             $userId,
@@ -146,7 +147,8 @@ class DebtSimulationService
                 unset($plan);
 
                 return $plans;
-            }
+            },
+            $ttl
         );
     }
 

--- a/config/ai.php
+++ b/config/ai.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'debt_simulation_cache_ttl' => 3600,
     'debt_simulation_strategies' => [
         \FireflyIII\Modules\AI\Simulations\Strategies\AvalancheStrategy::class,
         \FireflyIII\Modules\AI\Simulations\Strategies\SnowballStrategy::class,

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -6,6 +6,10 @@ The debt simulation endpoint evaluates multiple payoff strategies and returns ra
 
 `POST /api/v1/simulations/debt`
 
+## Configuration
+
+Simulation results are cached per user to speed up repeated requests. The cache lifetime in seconds is configured via `ai.debt_simulation_cache_ttl` in `config/ai.php` and defaults to `3600`.
+
 ## Request
 
 ```json


### PR DESCRIPTION
## Summary
- allow configuring debt simulation cache time
- read TTL from config in debt simulation service
- document debt simulation cache TTL option

## Testing
- `php -l config/ai.php app/Modules/AI/Simulations/DebtSimulationService.php`
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa vendor/bin/phpstan analyse config/ai.php app/Modules/AI/Simulations/DebtSimulationService.php` *(fails: Result is incomplete because of severe errors; Child process error: PHPStan process crashed because it reached configured PHP memory limit: 128M)*
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa vendor/bin/phpunit --testsuite unit --no-coverage` *(fails: Allowed memory size of 134217728 bytes exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_689e0497a5408326aac74207f777d200