### PR TITLE
test: ensure BalancedStrategy reset clears weights

### DIFF
--- a/tests/unit/Modules/AI/BalancedStrategyResetTest.php
+++ b/tests/unit/Modules/AI/BalancedStrategyResetTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\unit\Modules\AI;
+
+use FireflyIII\Modules\AI\Simulations\Strategies\BalancedStrategy;
+use Tests\integration\TestCase;
+
+/**
+ * @group unit-test
+ * @group ai
+ */
+final class BalancedStrategyResetTest extends TestCase
+{
+    public function testResetBetweenSimulations(): void
+    {
+        $strategy = new BalancedStrategy();
+
+        $debts = [
+            ['balance' => 1000.0],
+            ['balance' => 500.0],
+        ];
+
+        // First simulation alters internal weights
+        self::assertSame(0, $strategy->selectTargetDebt($debts));
+        self::assertSame(1, $strategy->selectTargetDebt($debts));
+
+        // Reset before running second simulation
+        $strategy->reset();
+
+        // After reset, first selection should follow balance proportions
+        self::assertSame(0, $strategy->selectTargetDebt($debts));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test confirming BalancedStrategy resets internal weights between simulations

## Testing
- `composer unit-test`
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= vendor/bin/phpstan analyse --no-progress tests/unit/Modules/AI/BalancedStrategyResetTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689e0bed57b483268b0721e19fceb511