### PR TITLE
Add time-to-deadline feature

### DIFF
--- a/fe/features/time_to_deadline.py
+++ b/fe/features/time_to_deadline.py
@@ -1,0 +1,24 @@
+"""Feature utilities for time-based calculations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+
+def time_to_deadline(
+    deadline: Optional[datetime],
+    now: Optional[datetime] = None,
+) -> float:
+    """Return the days until a market's resolution deadline.
+
+    Positive values indicate the deadline is in the future while negative
+    values indicate it has already passed.  If ``deadline`` is ``None`` a
+    ``NaN`` value is returned.
+    """
+    if deadline is None:
+        return float("nan")
+    if now is None:
+        now = datetime.utcnow()
+    delta = deadline - now
+    return delta.total_seconds() / 86400

--- a/tests/fe/test_time_to_deadline.py
+++ b/tests/fe/test_time_to_deadline.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+from math import isnan
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from fe.features.time_to_deadline import time_to_deadline  # noqa: E402
+
+
+def test_future_deadline():
+    now = datetime(2024, 1, 1)
+    deadline = now + timedelta(days=5)
+    result = time_to_deadline(deadline, now=now)
+    assert result == pytest.approx(5)
+
+
+def test_past_deadline():
+    now = datetime(2024, 1, 10)
+    deadline = now - timedelta(days=3)
+    result = time_to_deadline(deadline, now=now)
+    assert result == pytest.approx(-3)
+
+
+def test_null_deadline():
+    now = datetime(2024, 1, 1)
+    result = time_to_deadline(None, now=now)
+    assert isnan(result)


### PR DESCRIPTION
## Summary
- add utility to compute days until market resolution
- handle missing deadlines with `NaN`
- cover future, past, and null deadlines in tests

## Testing
- `flake8 fe/features/time_to_deadline.py tests/fe/test_time_to_deadline.py`
- `pytest tests/fe/test_time_to_deadline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f31e4a4ac83269e5f78c945d92197