### PR TITLE
feat: add liquidity feature

### DIFF
--- a/fe/features/__init__.py
+++ b/fe/features/__init__.py
@@ -1,0 +1,5 @@
+"""Feature computation utilities."""
+
+from .liquidity import compute_liquidity
+
+__all__ = ["compute_liquidity"]

--- a/fe/features/liquidity.py
+++ b/fe/features/liquidity.py
@@ -1,0 +1,62 @@
+"""Liquidity feature computation.
+
+This module provides utilities to compute liquidity metrics from
+order book snapshots.  The primary entry point is
+:func:`compute_liquidity`, which calculates the average depth across
+the bid and ask sides of the book over a lookback window.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+
+
+def _depth(levels: Sequence[Sequence[float]]) -> float:
+    """Return total quantity depth for a list of price levels."""
+    if levels is None:
+        return 0.0
+    return float(sum(level[1] for level in levels))
+
+
+def compute_liquidity(df: pd.DataFrame, hours: int = 1) -> pd.Series:
+    """Compute average bid/ask depth for each market.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing order book snapshots with the following
+        columns:
+            ``market_id`` – market identifier
+            ``timestamp`` – snapshot timestamp
+            ``bids`` – iterable of ``[price, quantity]`` pairs for bids
+            ``asks`` – iterable of ``[price, quantity]`` pairs for asks
+    hours:
+        Lookback window in hours.  Only snapshots within the past
+        ``hours`` from the most recent timestamp are considered.
+
+    Returns
+    -------
+    pd.Series
+        Series indexed by market ID with the average depth computed as
+        ``0.5 * (bid_depth + ask_depth)`` across snapshots in the
+        window.
+    """
+    if df.empty:
+        return pd.Series(dtype=float)
+
+    data = df.copy()
+    data["timestamp"] = pd.to_datetime(data["timestamp"], utc=True)
+
+    cutoff = data["timestamp"].max() - pd.Timedelta(hours=hours)
+    window = data[data["timestamp"] >= cutoff]
+
+    bid_depth = window["bids"].apply(_depth)
+    ask_depth = window["asks"].apply(_depth)
+    depth = 0.5 * (bid_depth + ask_depth)
+
+    return depth.groupby(window["market_id"]).mean()
+
+
+__all__ = ["compute_liquidity"]

--- a/tests/python/test_liquidity.py
+++ b/tests/python/test_liquidity.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import pandas as pd
+from fe.features import compute_liquidity
+
+
+def test_compute_liquidity_averages_depth_over_window():
+    data = [
+        {
+            "market_id": "m1",
+            "timestamp": "2024-01-01T08:00:00Z",
+            "bids": [(0.5, 1.0)],
+            "asks": [(0.6, 1.0)],
+        },
+        {
+            "market_id": "m1",
+            "timestamp": "2024-01-01T10:00:00Z",
+            "bids": [(0.5, 10.0), (0.4, 5.0)],
+            "asks": [(0.6, 7.0), (0.7, 3.0)],
+        },
+        {
+            "market_id": "m1",
+            "timestamp": "2024-01-01T11:00:00Z",
+            "bids": [(0.5, 8.0)],
+            "asks": [(0.6, 9.0)],
+        },
+        {
+            "market_id": "m2",
+            "timestamp": "2024-01-01T10:30:00Z",
+            "bids": [(0.3, 4.0)],
+            "asks": [(0.4, 6.0), (0.5, 2.0)],
+        },
+    ]
+    df = pd.DataFrame(data)
+
+    result = compute_liquidity(df, hours=2)
+
+    assert set(result.index) == {"m1", "m2"}
+    assert result["m1"] == 10.5  # (12.5 + 8.5) / 2
+    assert result["m2"] == 6.0
+
+
+def test_empty_dataframe_returns_empty_series():
+    df = pd.DataFrame(columns=["market_id", "timestamp", "bids", "asks"])
+    result = compute_liquidity(df)
+    assert result.empty


### PR DESCRIPTION
## Summary
- add liquidity feature computing average depth per market over a lookback window
- expose compute_liquidity helper
- test liquidity calculations against sample order books

## Testing
- `ruff check fe/features tests/python`
- `PYTHONPATH=. pytest tests/python -q`


------
https://chatgpt.com/codex/tasks/task_e_689f31e5b1dc832691d957adea5eb619