### PR TITLE
feat: add market price skew feature

### DIFF
--- a/fe/__init__.py
+++ b/fe/__init__.py
@@ -1,0 +1,1 @@
+"""Finance Engine utilities."""

--- a/fe/features/skew.py
+++ b/fe/features/skew.py
@@ -1,0 +1,22 @@
+"""Market skew utilities.
+
+Measures the price imbalance between the yes and no sides of a binary
+market.  Positive values indicate the yes side is priced higher than
+the no side.  The result is normalized to the range [-1, 1].
+"""
+
+from __future__ import annotations
+
+
+def price_skew(yes: float, no: float) -> float:
+    """Return normalized price imbalance between ``yes`` and ``no`` prices.
+
+    When both sides are equally priced the skew is zero.  The output
+    ranges from -1 (``no`` priced at 1, ``yes`` at 0) to 1 (``yes`` priced
+    at 1, ``no`` at 0).  If both prices are zero, a skew of 0 is
+    returned.
+    """
+    total = yes + no
+    if total <= 0:
+        return 0.0
+    return (yes - no) / total

--- a/tests/test_skew.py
+++ b/tests/test_skew.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fe.features.skew import price_skew  # noqa: E402
+from pytest import approx  # noqa: E402
+
+
+def test_symmetric_market_has_zero_skew() -> None:
+    assert price_skew(0.5, 0.5) == approx(0)
+
+
+def test_skew_is_normalized() -> None:
+    assert price_skew(1.0, 0.0) == approx(1)
+    assert price_skew(0.0, 1.0) == approx(-1)


### PR DESCRIPTION
## Summary
- add `price_skew` utility to compute normalized price imbalance for binary markets
- cover extreme and symmetric cases with tests

## Testing
- `flake8 fe/__init__.py fe/features/skew.py tests/test_skew.py`
- `pytest tests/test_skew.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f31e6445483268a054adfba22b22d