### PR TITLE
Add rolling drift feature and tests

### DIFF
--- a/fe/__init__.py
+++ b/fe/__init__.py
@@ -1,0 +1,1 @@
+"""Finance Engine Python utilities."""

--- a/fe/features/__init__.py
+++ b/fe/features/__init__.py
@@ -1,0 +1,1 @@
+"""Feature engineering utilities for Finance Engine."""

--- a/fe/features/drift.py
+++ b/fe/features/drift.py
@@ -1,0 +1,27 @@
+"""Calculate rolling price change (drift) for price series."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def rolling_drift(prices: pd.Series, window: int = 1) -> pd.Series:
+    """Return the price change compared to ``window`` periods ago.
+
+    The function is fully vectorised using :meth:`pandas.Series.diff` and
+    therefore scales efficiently for large inputs.
+
+    Args:
+        prices: Series containing price data.
+        window: Number of periods to look back when computing the drift.
+            Must be a positive integer.
+
+    Returns:
+        A ``pd.Series`` with the same index as ``prices`` containing the
+        difference between the current value and the value ``window`` periods
+        ago. The first ``window`` entries will be ``NaN`` as insufficient data
+        exists to compute the drift.
+    """
+    if window < 1:
+        raise ValueError("window must be at least 1")
+
+    return prices.diff(periods=window)

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,28 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pandas as pd  # noqa: E402
+from fe.features.drift import rolling_drift  # noqa: E402
+
+
+def test_drift_upward():
+    prices = pd.Series([1, 2, 3, 4, 5])
+    expected = pd.Series([float("nan"), float("nan"), 2.0, 2.0, 2.0])
+    result = rolling_drift(prices, window=2)
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_drift_downward():
+    prices = pd.Series([5, 4, 3, 2, 1])
+    expected = pd.Series([float("nan"), float("nan"), -2.0, -2.0, -2.0])
+    result = rolling_drift(prices, window=2)
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_drift_flat():
+    prices = pd.Series([5, 5, 5, 5])
+    expected = pd.Series([float("nan"), float("nan"), 0.0, 0.0])
+    result = rolling_drift(prices, window=2)
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- implement vectorized rolling drift calculation using pandas
- add unit tests for upward, downward, and flat price scenarios

## Testing
- `flake8 fe/__init__.py fe/features/__init__.py fe/features/drift.py tests/test_drift.py`
- `pytest tests/test_drift.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f31e680c08326b4843555cb011c1b