### PR TITLE
Implement rule objectivity scoring for Polymarket rules

### DIFF
--- a/fe/features/rule_objectivity.py
+++ b/fe/features/rule_objectivity.py
@@ -1,0 +1,59 @@
+"""Heuristics for scoring clarity of Polymarket rules."""
+from __future__ import annotations
+
+from typing import Iterable, Optional
+import re
+
+CLEAR_KEYWORDS = {
+    "official",
+    "exact",
+    "no later than",
+    "based on",
+    "publicly",
+    "will be",
+    "determined by",
+}
+AMBIGUOUS_KEYWORDS = {
+    "ambiguity",
+    "sole discretion",
+    "discretion",
+    "tbd",
+    "unknown",
+    "may",
+    "might",
+    "could",
+    "subject to",
+    "admin",
+    "committee",
+}
+
+
+def score_rule_objectivity(rule: Optional[str]) -> str:
+    """Return objectivity score for ``rule``.
+
+    The score is one of ``"clear"``, ``"ambiguous"``, or ``"unknown"``.  A
+    rule is considered clear when it contains strong determinate language or
+    numeric thresholds.  It is considered ambiguous when it contains terms
+    suggesting discretion or uncertainty.  Missing or empty rules return
+    ``"unknown"``.
+    """
+    if not rule or not rule.strip():
+        return "unknown"
+
+    text = rule.lower()
+    ambiguous = any(kw in text for kw in AMBIGUOUS_KEYWORDS)
+    clear = any(kw in text for kw in CLEAR_KEYWORDS)
+    if re.search(r"\d", text):
+        clear = True
+
+    if ambiguous:
+        return "ambiguous"
+    if clear:
+        return "clear"
+    # Default to "clear" when text exists but heuristics find nothing
+    return "clear"
+
+
+def batch_score(rules: Iterable[Optional[str]]) -> list[str]:
+    """Vectorised wrapper around :func:`score_rule_objectivity`."""
+    return [score_rule_objectivity(rule) for rule in rules]


### PR DESCRIPTION
## Summary
- add `rule_objectivity` feature with keyword heuristics to score rule clarity
- provide batch helper for scoring lists of rules

## Testing
- `python -m flake8 -v fe/features/rule_objectivity.py`
- `pytest`
- `python - <<'PY'
import json, urllib.request
from fe.features.rule_objectivity import score_rule_objectivity
BASE_URL = "https://gamma-api.polymarket.com"
limit=50
offset=0
req = urllib.request.Request(
    f"{BASE_URL}/markets?state=resolved&limit={limit}&offset={offset}&order=-endDate",
    headers={"User-Agent": "Mozilla/5.0"},
)
with urllib.request.urlopen(req, timeout=30) as resp:
    markets = json.load(resp)
rules = [m.get('description') for m in markets]
scores = [score_rule_objectivity(r) for r in rules]
coverage = sum(score != 'unknown' for score in scores) / len(scores)
print('Total markets:', len(markets))
print('Coverage:', round(coverage, 3))
print('Nulls:', sum(s is None for s in scores))
print('Counts:', {s: scores.count(s) for s in set(scores)})
PY`

------
https://chatgpt.com/codex/tasks/task_e_689f31e748a48326961d55623eaffd73