### PR TITLE
Add slippage-aware market maker strategy

### DIFF
--- a/fe/features/__init__.py
+++ b/fe/features/__init__.py
@@ -1,1 +1,6 @@
 """Feature engineering utilities for Finance Engine."""
+
+from .liquidity import compute_liquidity
+from .skew import price_skew
+
+__all__ = ["compute_liquidity", "price_skew"]

--- a/fe/strategies/__init__.py
+++ b/fe/strategies/__init__.py
@@ -1,0 +1,3 @@
+"""Trading strategy implementations."""
+
+__all__ = ["maker"]

--- a/fe/strategies/maker.py
+++ b/fe/strategies/maker.py
@@ -1,0 +1,143 @@
+"""Market making strategy utilities.
+
+This module provides functions to quote two-sided markets using
+liquidity and skew features as inputs.  It also offers a simple
+slippage-aware backtesting framework with parameter tuning and
+computation of summary performance metrics.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Iterable, Tuple, Dict
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Quote:
+    """Bid/ask quote."""
+
+    bid: float
+    ask: float
+
+
+def make_quote(
+    yes: float,
+    no: float,
+    liquidity: float,
+    skew: float,
+    *,
+    spread: float = 0.02,
+    liq_weight: float = 0.5,
+    skew_weight: float = 0.5,
+) -> Quote:
+    """Return bid/ask quote around the mid price.
+
+    The width is contracted when liquidity is high and shifted according
+    to the market skew.
+    """
+
+    mid = 0.5 * (yes + no)
+    width = spread * (1 - liq_weight * liquidity)
+    adjustment = skew_weight * skew * width
+
+    bid = max(0.0, mid - width / 2 - adjustment)
+    ask = min(1.0, mid + width / 2 - adjustment)
+
+    return Quote(bid=bid, ask=ask)
+
+
+def run_backtest(
+    df: pd.DataFrame,
+    *,
+    spread: float,
+    liq_weight: float,
+    skew_weight: float,
+    slippage: float = 0.01,
+) -> pd.DataFrame:
+    """Run a slippage-aware backtest of the maker strategy.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with columns ``yes``, ``no``, ``liquidity`` and ``skew``.
+    spread, liq_weight, skew_weight:
+        Parameters passed to :func:`make_quote`.
+    slippage:
+        Executed trades are penalized by this absolute amount.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``bid_edge``, ``ask_edge`` and ``pnl``
+        for each timestamp.
+    """
+
+    quotes = df.apply(
+        lambda r: make_quote(
+            r["yes"],
+            r["no"],
+            r["liquidity"],
+            r["skew"],
+            spread=spread,
+            liq_weight=liq_weight,
+            skew_weight=skew_weight,
+        ),
+        axis=1,
+    )
+    qdf = pd.DataFrame(list(quotes), index=df.index)
+
+    bid_edge = qdf["bid"] - df["yes"] - slippage
+    ask_edge = df["no"] - qdf["ask"] - slippage
+    pnl = 0.5 * (bid_edge + ask_edge)
+
+    return pd.DataFrame({"bid_edge": bid_edge, "ask_edge": ask_edge, "pnl": pnl})
+
+
+def performance_metrics(results: pd.DataFrame) -> Dict[str, float]:
+    """Compute summary metrics from backtest results."""
+
+    trades = results[["bid_edge", "ask_edge"]].stack()
+    win_rate = float((trades > 0).mean())
+    mean_pnl = float(results["pnl"].mean())
+    return {"mean_pnl": mean_pnl, "win_rate": win_rate}
+
+
+def tune_parameters(
+    df: pd.DataFrame,
+    spreads: Iterable[float],
+    liq_weights: Iterable[float],
+    skew_weights: Iterable[float],
+    *,
+    slippage: float = 0.01,
+) -> Tuple[Dict[str, float], Dict[str, float]]:
+    """Grid search best parameters based on mean PnL."""
+
+    best_params: Dict[str, float] | None = None
+    best_metrics: Dict[str, float] | None = None
+    best_score = float("-inf")
+
+    for s, lw, sw in itertools.product(spreads, liq_weights, skew_weights):
+        res = run_backtest(
+            df, spread=s, liq_weight=lw, skew_weight=sw, slippage=slippage
+        )
+        metrics = performance_metrics(res)
+        score = metrics["mean_pnl"]
+        if score > best_score:
+            best_score = score
+            best_params = {"spread": s, "liq_weight": lw, "skew_weight": sw}
+            best_metrics = metrics
+
+    assert best_params is not None and best_metrics is not None
+    return best_params, best_metrics
+
+
+__all__ = [
+    "Quote",
+    "make_quote",
+    "run_backtest",
+    "performance_metrics",
+    "tune_parameters",
+]

--- a/tests/test_maker.py
+++ b/tests/test_maker.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+from pytest import approx
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fe.strategies.maker import (  # noqa: E402
+    make_quote,
+    performance_metrics,
+    run_backtest,
+    tune_parameters,
+)
+
+
+def sample_data() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "yes": [0.5, 0.55],
+            "no": [0.5, 0.45],
+            "liquidity": [0.2, 0.8],
+            "skew": [0.0, 0.1],
+        }
+    )
+
+
+def test_make_quote_uses_features() -> None:
+    quote = make_quote(0.6, 0.4, liquidity=1.0, skew=0.2, spread=0.1, liq_weight=0.5, skew_weight=0.5)
+    assert quote.bid == approx(0.47)
+    assert quote.ask == approx(0.52)
+
+
+def test_backtest_and_metrics() -> None:
+    data = sample_data()
+    res = run_backtest(data, spread=0.1, liq_weight=0.5, skew_weight=0.5, slippage=0.01)
+    metrics = performance_metrics(res)
+    assert set(res.columns) == {"bid_edge", "ask_edge", "pnl"}
+    assert "mean_pnl" in metrics and "win_rate" in metrics
+
+
+def test_tune_parameters() -> None:
+    data = sample_data()
+    params, metrics = tune_parameters(
+        data, spreads=[0.05, 0.1], liq_weights=[0.5], skew_weights=[0.5], slippage=0.01
+    )
+    assert set(params) == {"spread", "liq_weight", "skew_weight"}
+    assert "mean_pnl" in metrics


### PR DESCRIPTION
## Summary
- Add maker strategy to quote two-sided markets from liquidity and skew features
- Provide slippage-aware backtests with parameter tuning and performance metrics
- Export liquidity and skew helpers and add comprehensive tests

## Testing
- `ruff check fe tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f36c0e39883268ad3b625ee6941a1