### PR TITLE
Add rule objectivity strategy and evaluation utilities

### DIFF
--- a/fe/features/__init__.py
+++ b/fe/features/__init__.py
@@ -1,1 +1,16 @@
 """Feature engineering utilities for Finance Engine."""
+
+from .liquidity import compute_liquidity
+from .rule_objectivity import score_rule_objectivity, batch_score
+from .drift import rolling_drift
+from .skew import price_skew
+from .time_to_deadline import time_to_deadline
+
+__all__ = [
+    "compute_liquidity",
+    "score_rule_objectivity",
+    "batch_score",
+    "rolling_drift",
+    "price_skew",
+    "time_to_deadline",
+]

--- a/fe/strategies/__init__.py
+++ b/fe/strategies/__init__.py
@@ -1,0 +1,17 @@
+"""Trading strategy utilities."""
+
+from .rules_alpha import (
+    SlippageModel,
+    grid_search,
+    performance_report,
+    simulate,
+    walk_forward,
+)
+
+__all__ = [
+    "SlippageModel",
+    "grid_search",
+    "performance_report",
+    "simulate",
+    "walk_forward",
+]

--- a/fe/strategies/rules_alpha.py
+++ b/fe/strategies/rules_alpha.py
@@ -1,0 +1,143 @@
+"""Rule objectivity based trading strategy.
+
+This module provides a simple alpha factor that favours markets with
+"clear" resolution rules while avoiding those with "ambiguous" rules.
+It also includes utilities for applying a basic slippage model, running
+parameter grid searches, performing walk-forward evaluation and
+producing performance reports.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Sequence
+import itertools
+
+import numpy as np
+import pandas as pd
+
+from fe.features.rule_objectivity import batch_score
+
+# Map textual objectivity scores to numerical alpha values.
+_OBJECTIVITY_ALPHA = {"clear": 1.0, "unknown": 0.0, "ambiguous": -1.0}
+
+
+@dataclass
+class SlippageModel:
+    """Linear slippage model.
+
+    Parameters
+    ----------
+    rate:
+        Fractional slippage applied to each trade.  A ``rate`` of 0.001
+        represents 10 bps of price impact.
+    """
+
+    rate: float = 0.001
+
+    def apply(self, price: float, side: int) -> float:
+        """Return price adjusted for slippage.
+
+        ``side`` should be ``1`` for buys and ``-1`` for sells.
+        """
+
+        adjustment = price * self.rate
+        return price + adjustment if side > 0 else price - adjustment
+
+
+def _score_rules(rules: Sequence[str]) -> np.ndarray:
+    """Vectorised rule scoring helper."""
+
+    scores = batch_score(rules)
+    return np.array([_OBJECTIVITY_ALPHA[s] for s in scores], dtype=float)
+
+
+def simulate(df: pd.DataFrame, threshold: float, slippage: SlippageModel) -> pd.Series:
+    """Simulate strategy returns for ``df``.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing columns ``price`` and ``rule``.
+    threshold:
+        Minimum alpha required to go long.  Values below ``threshold``
+        result in short positions.
+    slippage:
+        Slippage model applied to trade prices.
+    """
+
+    if df.empty:
+        return pd.Series(dtype=float)
+
+    alpha = _score_rules(df["rule"].tolist())
+    side = np.where(alpha >= threshold, 1, -1)
+    prices = df["price"].astype(float).to_numpy()
+    executed = np.array([slippage.apply(p, s) for p, s in zip(prices, side)])
+    # Compute P&L from price changes in direction of the position.
+    pnl = (np.roll(executed, -1) - executed) * side
+    return pd.Series(pnl[:-1], index=df.index[:-1])
+
+
+def performance_report(returns: pd.Series) -> Dict[str, float]:
+    """Compute basic performance statistics."""
+
+    if returns.empty:
+        return {"trades": 0, "avg_return": 0.0, "sharpe": 0.0}
+    avg = float(returns.mean())
+    std = float(returns.std(ddof=0))
+    sharpe = avg / std if std else 0.0
+    return {"trades": int(returns.size), "avg_return": avg, "sharpe": sharpe}
+
+
+def grid_search(df: pd.DataFrame, thresholds: Iterable[float], slippages: Iterable[float]) -> Dict[str, Any]:
+    """Evaluate parameter combinations and return the best."""
+
+    best_params: Dict[str, float] | None = None
+    best_report: Dict[str, float] | None = None
+    for threshold, slip in itertools.product(thresholds, slippages):
+        model = SlippageModel(rate=slip)
+        ret = simulate(df, threshold, model)
+        report = performance_report(ret)
+        if best_report is None or report["avg_return"] > best_report["avg_return"]:
+            best_params = {"threshold": threshold, "slippage": slip}
+            best_report = report
+    return {"params": best_params, "report": best_report}
+
+
+def walk_forward(
+    df: pd.DataFrame,
+    train_size: int,
+    test_size: int,
+    thresholds: Iterable[float],
+    slippages: Iterable[float],
+) -> pd.DataFrame:
+    """Perform walk-forward evaluation.
+
+    The data is split into sequential train/test windows.  For each
+    window a grid search is executed on the training portion and the
+    best parameters are applied to the subsequent test slice.  A
+    performance report for each period is returned as a DataFrame.
+    """
+
+    results: list[Dict[str, Any]] = []
+    start = 0
+    while start + train_size + test_size <= len(df):
+        train = df.iloc[start : start + train_size]
+        test = df.iloc[start + train_size : start + train_size + test_size]
+        params = grid_search(train, thresholds, slippages)["params"]
+        model = SlippageModel(rate=params["slippage"])
+        ret = simulate(test, params["threshold"], model)
+        rep = performance_report(ret)
+        rep.update(params)
+        rep["start"] = test.index[0]
+        results.append(rep)
+        start += test_size
+    return pd.DataFrame(results)
+
+
+__all__ = [
+    "SlippageModel",
+    "simulate",
+    "performance_report",
+    "grid_search",
+    "walk_forward",
+]


### PR DESCRIPTION
## Summary
- add rule-objectivity-driven trading strategy with slippage model, grid search, walk-forward evaluation, and performance report
- expose core feature utilities via `fe.features`

## Testing
- `ruff check fe/features/__init__.py fe/strategies/rules_alpha.py fe/strategies/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f36c07c008326a925da32565e2198