### PR TITLE
Add deadline-based strategy with backtesting utilities

### DIFF
--- a/fe/backtest.py
+++ b/fe/backtest.py
@@ -1,0 +1,52 @@
+"""Backtesting utilities including parameter grid search and walk-forward validation."""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Dict, Iterable, List, Type
+
+import numpy as np
+import pandas as pd
+
+
+def parameter_grid(param_grid: Dict[str, Iterable[float]]) -> List[Dict[str, float]]:
+    """Return a list of dictionaries for all combinations in ``param_grid``."""
+
+    keys = list(param_grid)
+    combos = product(*(param_grid[k] for k in keys))
+    return [dict(zip(keys, values)) for values in combos]
+
+
+def walk_forward_validation(
+    df: pd.DataFrame,
+    strategy_cls: Type,
+    param_grid: Dict[str, Iterable[float]],
+    train_size: int,
+    test_size: int,
+    price_col: str = "no_price",
+) -> pd.DataFrame:
+    """Perform walk-forward validation for ``strategy_cls`` on ``df``.
+
+    Each step fits the best parameters (by Sharpe ratio) on the training window
+    and evaluates them on the subsequent test window.
+    """
+
+    results: List[Dict[str, float]] = []
+    for start in range(0, len(df) - train_size - test_size + 1, test_size):
+        train = df.iloc[start : start + train_size]
+        test = df.iloc[start + train_size : start + train_size + test_size]
+        best_params: Dict[str, float] | None = None
+        best_sharpe = -np.inf
+        for params in parameter_grid(param_grid):
+            strat = strategy_cls(**params)
+            metrics = strat.backtest(train, price_col=price_col, n_shuffle=0)
+            if metrics["sharpe"] > best_sharpe:
+                best_sharpe = metrics["sharpe"]
+                best_params = params
+        if best_params is None:
+            continue
+        strat = strategy_cls(**best_params)
+        eval_metrics = strat.backtest(test, price_col=price_col)
+        eval_metrics.update(best_params)
+        results.append(eval_metrics)
+    return pd.DataFrame(results)

--- a/fe/features/__init__.py
+++ b/fe/features/__init__.py
@@ -1,1 +1,5 @@
 """Feature engineering utilities for Finance Engine."""
+
+from .liquidity import compute_liquidity
+
+__all__ = ["compute_liquidity"]

--- a/fe/strategies/__init__.py
+++ b/fe/strategies/__init__.py
@@ -1,0 +1,5 @@
+"""Strategy implementations for Finance Engine."""
+
+from .deadline_no import DeadlineNoStrategy
+
+__all__ = ["DeadlineNoStrategy"]

--- a/fe/strategies/deadline_no.py
+++ b/fe/strategies/deadline_no.py
@@ -1,0 +1,83 @@
+"""Strategy trading "no" shares based on time to deadline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class DeadlineNoStrategy:
+    """Simple strategy that buys "no" shares as a market nears resolution.
+
+    Parameters
+    ----------
+    entry_days:
+        Enter a long "no" position when time to deadline is less than or
+        equal to this number of days.
+    exit_days:
+        Exit the position when time to deadline is less than or equal to this
+        threshold.  Defaults to ``0`` (resolution).
+    """
+
+    entry_days: float
+    exit_days: float = 0.0
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        """Return binary trading signals for each row of ``df``.
+
+        ``df`` must contain a ``time_to_deadline`` column expressed in days.
+        Positions are ``1`` for long "no" and ``0`` for flat.
+        """
+
+        tt = df["time_to_deadline"]
+        long_mask = (tt <= self.entry_days) & (tt > self.exit_days)
+        return long_mask.astype(int)
+
+    def backtest(
+        self,
+        df: pd.DataFrame,
+        price_col: str = "no_price",
+        n_shuffle: int = 100,
+        seed: int | None = None,
+    ) -> Dict[str, float]:
+        """Run a vectorised backtest on ``df`` and return performance metrics."""
+
+        prices = df[price_col]
+        signal = self.generate_signals(df)
+        position = signal.shift().fillna(0)
+        returns = prices.pct_change().fillna(0)
+        pnl = position * returns
+
+        equity = (1 + pnl).cumprod()
+        pnl_total = equity.iloc[-1] - 1
+        sharpe = 0.0
+        if pnl.std() > 0:
+            sharpe = pnl.mean() / pnl.std() * np.sqrt(252)
+        drawdown = (equity / equity.cummax() - 1).min()
+        hit_rate = float((pnl > 0).mean())
+        turnover = float(position.diff().abs().sum() / 2)
+
+        rng = np.random.default_rng(seed)
+        shuffled = []
+        for _ in range(n_shuffle):
+            shuffled_signal = pd.Series(rng.permutation(signal.to_numpy()), index=signal.index)
+            sh_pos = shuffled_signal.shift().fillna(0)
+            sh_pnl = sh_pos * returns
+            if sh_pnl.std() > 0:
+                shuffled.append(sh_pnl.mean() / sh_pnl.std() * np.sqrt(252))
+            else:
+                shuffled.append(0.0)
+        pvalue = (np.sum(np.array(shuffled) >= sharpe) + 1) / (n_shuffle + 1)
+
+        return {
+            "pnl": float(pnl_total),
+            "sharpe": float(sharpe),
+            "max_drawdown": float(drawdown),
+            "hit_rate": hit_rate,
+            "turnover": turnover,
+            "shuffled_pvalue": float(pvalue),
+        }

--- a/tests/fe/test_deadline_no_strategy.py
+++ b/tests/fe/test_deadline_no_strategy.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fe.strategies.deadline_no import DeadlineNoStrategy  # noqa: E402
+from fe.backtest import walk_forward_validation  # noqa: E402
+
+
+def make_data(n: int = 60) -> pd.DataFrame:
+    tt = np.linspace(30, -1, n)
+    prices = 0.5 + 0.1 * np.sin(np.linspace(0, 3, n))
+    return pd.DataFrame({"time_to_deadline": tt, "no_price": prices})
+
+
+def test_strategy_metrics():
+    df = make_data()
+    strat = DeadlineNoStrategy(entry_days=10, exit_days=0)
+    metrics = strat.backtest(df)
+    assert set("pnl sharpe max_drawdown hit_rate turnover shuffled_pvalue".split()).issubset(metrics)
+    assert 0 <= metrics["hit_rate"] <= 1
+    assert 0 <= metrics["shuffled_pvalue"] <= 1
+
+
+def test_walk_forward_validation():
+    df = make_data(80)
+    param_grid = {"entry_days": [12, 10], "exit_days": [0, -1]}
+    results = walk_forward_validation(df, DeadlineNoStrategy, param_grid, train_size=40, test_size=10)
+    assert not results.empty
+    assert {"pnl", "sharpe", "max_drawdown", "hit_rate", "turnover", "shuffled_pvalue"}.issubset(results.columns)
+    # ensure parameters used are from grid
+    assert set(results["entry_days"]).issubset({12, 10})
+    assert set(results["exit_days"]).issubset({0, -1})


### PR DESCRIPTION
## Summary
- implement `DeadlineNoStrategy` that trades "no" shares based on time to deadline and reports PnL, Sharpe, MDD, hit-rate, turnover and significance vs. shuffled labels
- add generic backtest utilities supporting parameter grids and walk-forward validation
- expose liquidity feature and cover strategy/backtest with unit tests

## Testing
- `ruff check fe/strategies/deadline_no.py fe/backtest.py tests/fe/test_deadline_no_strategy.py fe/features/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f36c0223c8326b4d6203b3121b1e9