### PR TITLE
feat: add vectorized backtest utility

### DIFF
--- a/fe/features/__init__.py
+++ b/fe/features/__init__.py
@@ -1,1 +1,5 @@
 """Feature engineering utilities for Finance Engine."""
+
+from .liquidity import compute_liquidity
+
+__all__ = ["compute_liquidity"]

--- a/fe/strategies/__init__.py
+++ b/fe/strategies/__init__.py
@@ -1,0 +1,5 @@
+"""Strategy utilities."""
+
+from .backtest import run_backtest
+
+__all__ = ["run_backtest"]

--- a/fe/strategies/backtest.py
+++ b/fe/strategies/backtest.py
@@ -1,0 +1,85 @@
+"""Vectorized backtesting helpers.
+
+This module provides utilities for running simple vectorized
+backtests over a grid of parameter values.  Strategies are
+expected to return a ``pd.Series`` of desired positions.  Slippage
+costs are applied whenever the position changes.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Callable, Dict, Iterable, Sequence
+
+import pandas as pd
+
+
+def _simulate(prices: pd.Series, positions: pd.Series, slippage: float) -> pd.Series:
+    """Compute per-period returns given prices and positions.
+
+    Parameters
+    ----------
+    prices:
+        Series of prices indexed by time.
+    positions:
+        Series of target positions for each period.
+    slippage:
+        Fractional cost applied to position changes.
+
+    Returns
+    -------
+    pd.Series
+        Series of returns for each period.
+    """
+    prices = prices.astype(float)
+    pct_change = prices.pct_change().fillna(0.0)
+    trades = positions.diff().abs().fillna(0.0)
+    returns = positions.shift().fillna(0.0) * pct_change - slippage * trades
+    return returns
+
+
+def run_backtest(
+    strategy: Callable[..., pd.Series],
+    data: pd.DataFrame,
+    params: Dict[str, Sequence],
+    slippage: float = 0.0,
+) -> pd.DataFrame:
+    """Run a strategy over a grid of parameters.
+
+    Parameters
+    ----------
+    strategy:
+        Callable accepting ``data`` and parameter values and returning a
+        Series of positions.
+    data:
+        Input DataFrame containing at least a ``price`` column.
+    params:
+        Mapping from parameter name to a sequence of values to search.
+    slippage:
+        Fractional slippage cost applied to position changes.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame where each row corresponds to a parameter combination
+        with an additional ``return`` column containing the cumulative
+        return over the run.
+    """
+    if "price" not in data.columns:
+        raise ValueError("data must contain a 'price' column")
+
+    names = list(params)
+    grid: Iterable[Sequence] = product(*params.values()) if names else [()]
+
+    results = []
+    for combo in grid:
+        kwargs = dict(zip(names, combo))
+        positions = strategy(data, **kwargs)
+        returns = _simulate(data["price"], positions, slippage)
+        total_return = (1.0 + returns).prod() - 1.0
+        results.append({**kwargs, "return": total_return})
+
+    return pd.DataFrame(results)
+
+
+__all__ = ["run_backtest"]

--- a/tests/python/test_backtest.py
+++ b/tests/python/test_backtest.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import pandas as pd
+import pytest
+
+from fe.strategies import run_backtest
+
+
+def buy_and_hold(_data):
+    return pd.Series(1, index=_data.index)
+
+
+def threshold_strategy(data, threshold):
+    returns = data["price"].pct_change().fillna(0.0)
+    return (returns > threshold).astype(int)
+
+
+def test_run_backtest_buy_and_hold():
+    df = pd.DataFrame({"price": [1.0, 1.1, 1.2]})
+    result = run_backtest(buy_and_hold, df, {})
+    assert result.shape[0] == 1
+    assert result["return"].iloc[0] == pytest.approx(0.2, rel=1e-9)
+
+
+def test_slippage_and_grid_search():
+    df = pd.DataFrame({"price": [1.0, 1.2, 1.1, 1.3]})
+    params = {"threshold": [0.0, 0.05]}
+    grid = run_backtest(threshold_strategy, df, params, slippage=0.0)
+    assert set(grid["threshold"]) == {0.0, 0.05}
+
+    no_slip = run_backtest(threshold_strategy, df, {"threshold": [0.0]}, slippage=0.0)
+    with_slip = run_backtest(threshold_strategy, df, {"threshold": [0.0]}, slippage=0.01)
+    assert with_slip["return"].iloc[0] < no_slip["return"].iloc[0]


### PR DESCRIPTION
## Summary
- add vectorized backtesting helpers with configurable slippage and parameter grid search
- expose compute_liquidity in features package for tests
- cover backtest utility with synthetic-data unit tests

## Testing
- `ruff check fe/strategies/backtest.py fe/features/__init__.py tests/python/test_backtest.py`
- `pytest tests/python -q`

------
https://chatgpt.com/codex/tasks/task_e_689f36bf24ec8326a7980e19b1d9f3fe