### PR TITLE
Add base rate estimator with isotonic regression calibration

### DIFF
--- a/fe/base_rates/__init__.py
+++ b/fe/base_rates/__init__.py
@@ -1,0 +1,3 @@
+from .estimator import estimate_prior
+
+__all__ = ["estimate_prior"]

--- a/fe/base_rates/estimator.py
+++ b/fe/base_rates/estimator.py
@@ -1,0 +1,91 @@
+"""Base rate estimator using isotonic regression.
+
+This module provides `estimate_prior` for computing outside-view priors
+based on historical resolution data. Probabilities are calibrated using
+isotonic regression to ensure monotonicity with respect to the time
+horizon. A Wilson score interval is returned as a measure of
+uncertainty.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.isotonic import IsotonicRegression
+
+_DATA: pd.DataFrame | None = None
+_MODELS: Dict[str, Tuple[IsotonicRegression, pd.DataFrame]] = {}
+
+
+def _load_data() -> None:
+    """Load historical resolution data and fit isotonic models."""
+    global _DATA
+    if _DATA is not None:
+        return
+    data_path = Path(__file__).with_name("historical.csv")
+    _DATA = pd.read_csv(data_path)
+    for cat, df_cat in _DATA.groupby("category"):
+        model = IsotonicRegression(out_of_bounds="clip")
+        model.fit(df_cat["horizon_days"], df_cat["outcome"])
+        _MODELS[cat] = (model, df_cat)
+
+
+def _wilson_interval(
+    successes: float, n: int, z: float = 1.96
+) -> Tuple[float, float]:
+    """Return Wilson score interval for a binomial proportion."""
+    if n == 0:
+        return 0.0, 1.0
+    phat = successes / n
+    denom = 1 + z**2 / n
+    center = phat + z**2 / (2 * n)
+    margin = z * np.sqrt(
+        (phat * (1 - phat) + z**2 / (4 * n)) / n
+    )
+    lower = (center - margin) / denom
+    upper = (center + margin) / denom
+    return float(lower), float(upper)
+
+
+def estimate_prior(
+    category: str, deadline: datetime
+) -> Tuple[float, Tuple[float, float]]:
+    """Estimate the base rate for ``category`` with ``deadline``.
+
+    Parameters
+    ----------
+    category:
+        Category string present in the historical data.
+    deadline:
+        Datetime of the event deadline.
+
+    Returns
+    -------
+    prob, (lower, upper):
+        Calibrated probability and 95%% confidence interval.
+    """
+    _load_data()
+    if category not in _MODELS:
+        raise ValueError(f"unknown category: {category}")
+
+    horizon = (deadline - datetime.utcnow()).days
+    horizon = max(horizon, 0)
+
+    model, df_cat = _MODELS[category]
+    prob = float(model.predict([horizon])[0])
+
+    window = 30
+    mask = (
+        (df_cat["horizon_days"] >= horizon - window)
+        & (df_cat["horizon_days"] <= horizon + window)
+    )
+    window_df = df_cat[mask]
+    if window_df.empty:
+        window_df = df_cat
+    successes = window_df["outcome"].sum()
+    n = len(window_df)
+    ci = _wilson_interval(successes, n)
+    return prob, ci

--- a/fe/base_rates/historical.csv
+++ b/fe/base_rates/historical.csv
@@ -1,0 +1,9 @@
+category,horizon_days,outcome
+politics,30,0
+politics,60,0
+politics,90,1
+politics,120,1
+sports,30,1
+sports,60,1
+sports,90,0
+sports,120,0

--- a/tests/python/test_base_rates.py
+++ b/tests/python/test_base_rates.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from datetime import datetime, timedelta  # noqa: E402
+
+from fe.base_rates import estimate_prior  # noqa: E402
+
+
+def test_estimate_prior_mid_horizon():
+    deadline = datetime.utcnow() + timedelta(days=75)
+    prob, ci = estimate_prior("politics", deadline)
+    assert 0.45 < prob < 0.55
+    assert ci[0] < prob < ci[1]
+
+
+def test_estimate_prior_unknown_category():
+    deadline = datetime.utcnow() + timedelta(days=30)
+    try:
+        estimate_prior("unknown", deadline)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for unknown category")


### PR DESCRIPTION
## Summary
- introduce base rate estimator using isotonic regression and Wilson score intervals
- add sample historical data and expose `estimate_prior` API
- cover estimator with unit tests

## Testing
- `flake8 fe/base_rates tests/python/test_base_rates.py`
- `pytest tests/python/test_base_rates.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3ae01eec83268726e357a73b79a0