### PR TITLE
Add strategy sign-off gate with tests

### DIFF
--- a/fe/signoff/__init__.py
+++ b/fe/signoff/__init__.py
@@ -1,0 +1,5 @@
+"""Strategy sign-off utilities."""
+
+from .gate import approve
+
+__all__ = ["approve"]

--- a/fe/signoff/gate.py
+++ b/fe/signoff/gate.py
@@ -1,0 +1,36 @@
+"""Simple gate for approving strategy reports.
+
+A strategy is approved if it satisfies three conditions:
+- ``sample_size`` is at least ``MIN_SAMPLE``
+- ``max_drawdown`` does not exceed ``MAX_MDD``
+- ``p_value`` is below ``ALPHA``
+"""
+from __future__ import annotations
+
+from typing import Mapping
+
+MIN_SAMPLE = 30
+MAX_MDD = 0.2
+ALPHA = 0.05
+
+
+def approve(strategy_report: Mapping[str, float | int]) -> bool:
+    """Return True if the strategy report passes all gates.
+
+    Parameters
+    ----------
+    strategy_report:
+        Mapping containing ``sample_size``, ``max_drawdown`` and ``p_value``.
+
+    Returns
+    -------
+    bool
+        True when all metrics meet their respective thresholds.
+    """
+    sample = strategy_report.get("sample_size", 0)
+    mdd = strategy_report.get("max_drawdown", float("inf"))
+    pval = strategy_report.get("p_value", 1.0)
+    return sample >= MIN_SAMPLE and mdd <= MAX_MDD and pval < ALPHA
+
+
+__all__ = ["approve", "MIN_SAMPLE", "MAX_MDD", "ALPHA"]

--- a/tests/fe/signoff/test_gate.py
+++ b/tests/fe/signoff/test_gate.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+from fe.signoff.gate import approve  # noqa: E402
+
+
+def test_gate_passes_when_all_thresholds_met():
+    report = {"sample_size": 50, "max_drawdown": 0.1, "p_value": 0.01}
+    assert approve(report)
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        {"sample_size": 10, "max_drawdown": 0.1, "p_value": 0.01},
+        {"sample_size": 50, "max_drawdown": 0.3, "p_value": 0.01},
+        {"sample_size": 50, "max_drawdown": 0.1, "p_value": 0.2},
+    ],
+)
+def test_gate_rejects_when_any_threshold_fails(report):
+    assert not approve(report)


### PR DESCRIPTION
## Summary
- add a sign-off gate that approves strategy reports when sample size, drawdown, and p-value meet thresholds
- expose `approve` function from sign-off package
- cover passing and failing scenarios with unit tests

## Testing
- `flake8 fe/signoff/gate.py tests/fe/signoff/test_gate.py`
- `pytest tests/fe/signoff/test_gate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f45a0dc74832685637d2352800bb0