### PR TITLE
feat: package strategies into wheel

### DIFF
--- a/.github/workflows/strategy-wheel.yml
+++ b/.github/workflows/strategy-wheel.yml
@@ -1,0 +1,26 @@
+name: Build strategy wheel
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Set version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+      - name: Install build tools
+        run: pip install build
+      - name: Build wheel
+        run: python fe/export/build.py $VERSION
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: polymarket_alpha_${{ env.VERSION }}.whl
+          path: dist/polymarket_alpha_${{ env.VERSION }}.whl

--- a/fe/export/__init__.py
+++ b/fe/export/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for exporting strategy packages."""

--- a/fe/export/build.py
+++ b/fe/export/build.py
@@ -1,0 +1,108 @@
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+STRATEGIES = ["cross_pairs", "deadline_no", "maker", "rules_alpha"]
+
+
+def build_wheel(version: str, strategies: list[str]) -> Path:
+    """Package selected strategies into a wheel.
+
+    Parameters
+    ----------
+    version: str
+        Semver version string for the wheel.
+    strategies: list[str]
+        Strategy module names to include.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    dist_dir = repo_root / "dist"
+    dist_dir.mkdir(exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pkg_dir = Path(tmpdir) / "polymarket_alpha"
+        (pkg_dir / "strategies").mkdir(parents=True)
+
+        # Strategy interface
+        (pkg_dir / "__init__.py").write_text(
+            """from abc import ABC, abstractmethod
+
+class Strategy(ABC):
+    \"\"\"Interface for trading strategies.\"\"\"
+
+    @abstractmethod
+    def propose_orders(self, market_state):
+        \"\"\"Return proposed orders for the given market state.\"\"\"
+
+    @abstractmethod
+    def on_fill(self, fill):
+        \"\"\"Handle an order fill event.\"\"\"
+
+    @abstractmethod
+    def risk_profile(self):
+        \"\"\"Return risk parameters for the strategy.\"\"\"
+"""
+        )
+
+        # Copy selected strategies
+        src_strategies = repo_root / "fe" / "strategies"
+        for name in strategies:
+            src = src_strategies / f"{name}.py"
+            if not src.exists():
+                raise FileNotFoundError(f"Strategy '{name}' not found")
+            shutil.copy(src, pkg_dir / "strategies" / src.name)
+
+        # Minimal pyproject for packaging
+        (Path(tmpdir) / "pyproject.toml").write_text(
+            f"""
+[build-system]
+requires = [\"setuptools>=61\", \"wheel\"]
+build-backend = \"setuptools.build_meta\"
+
+[project]
+name = \"polymarket_alpha\"
+version = \"{version}\"
+description = \"Selected strategy implementations for Polymarket Alpha\"
+"""
+        )
+
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "build",
+                "--wheel",
+                "--outdir",
+                str(dist_dir),
+            ],
+            cwd=tmpdir,
+        )
+
+    # Rename generated wheel to expected filename
+    wheel = next(dist_dir.glob("polymarket_alpha-*.whl"))
+    target = dist_dir / f"polymarket_alpha_{version}.whl"
+    wheel.rename(target)
+    return target
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build polymarket_alpha wheel"
+    )
+    parser.add_argument("version", help="Semver version for the wheel")
+    parser.add_argument(
+        "--strategies",
+        nargs="+",
+        default=STRATEGIES,
+        help="List of strategy module names to include",
+    )
+    args = parser.parse_args()
+    build_wheel(args.version, args.strategies)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add build script to bundle select strategies into polymarket_alpha wheel
- publish wheel on tagged releases via new GitHub workflow

## Testing
- `flake8 fe/export`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f45a1302c8326b7944e58378cd9da