### PR TITLE
Normalize debt simulation cache key by account order

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -74,7 +74,12 @@ class DebtSimulationService
             return [];
         }
 
-        $hash     = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
+        // Sort accounts by ID so that the cache key is order-independent.
+        // Different permutations of the same accounts should hit the same cache entry.
+        $accountsForHash = $accounts;
+        usort($accountsForHash, static fn(array $a, array $b): int => ($a['account_id'] ?? '') <=> ($b['account_id'] ?? ''));
+
+        $hash     = hash('sha256', serialize([$accountsForHash, $budget, $maxOptions]));
         $cacheKey = 'debt-sim-' . $hash;
         $ttl      = (int) config('ai.debt_simulation_cache_ttl', 3600);
 


### PR DESCRIPTION
## Summary
- ensure debt simulation cache key sorts accounts by ID

## Testing
- `vendor/bin/phpstan analyse app/Modules/AI/Simulations/DebtSimulationService.php --memory-limit=512M`
- `composer unit-test`


------
https://chatgpt.com/codex/tasks/task_e_689f49526bbc8326b6edde1ee4fd7e8e