### PR TITLE
Expose debt simulation status in API response

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -71,6 +71,7 @@ class DebtController extends Controller
                     'plan'       => [
                         'strategy' => $plan['strategy'],
                         'schedule' => $plan['schedule'],
+                        'status'   => $plan['status'],
                     ],
                     'metrics' => [
                         'interest_saved'        => (float) $plan['interest_saved'],

--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -122,6 +122,9 @@ class DebtSimulationService
                 $worstInterest = $interestList !== [] ? max($interestList) : 0.0;
 
                 foreach ($plans as $i => &$plan) {
+                    // Preserve the original status in case additional metrics overwrite keys.
+                    $status = $plan['status'] ?? 'ok';
+
                     $plan['rank']                  = $i + 1;
                     $plan['is_optimal']            = 0 === $i;
                     $plan['total_interest']        = (float) $plan['total_interest'];
@@ -148,6 +151,9 @@ class DebtSimulationService
                             'tradeoffs'         => $tradeoffString,
                         ]
                     );
+
+                    // Re-attach the status so consumers can understand convergence state.
+                    $plan['status'] = $status;
                 }
                 unset($plan);
 
@@ -226,7 +232,7 @@ class DebtSimulationService
             $remainingBudget = max($remainingBudget, 0.0);
 
             // Allocate any extra budget to targeted debt(s).
-            while ($remainingBudget > 0 && $this->hasBalance($debts)) { // @phpstan-ignore-line
+            while ($remainingBudget > 0 && $this->hasBalance($debts)) {
                 $targetKey = $strategy->selectTargetDebt($debts);
                 if (null === $targetKey) {
                     break;

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -105,7 +105,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
                 [
                     'rank',
                     'is_optimal',
-                    'plan'    => ['strategy', 'schedule'],
+                    'plan'    => ['strategy', 'schedule', 'status'],
                     'metrics' => [
                         'interest_saved',
                         'time_to_payoff_months',
@@ -118,8 +118,11 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         ]);
         self::assertTrue(Str::isUuid($response1->json('analysis_id')));
         self::assertNotEmpty($response1->json('proposed_actions.0.plan.schedule'));
+        self::assertIsString($response1->json('proposed_actions.0.plan.status'));
         $actions = $response1->json('proposed_actions');
         foreach ($actions as $action) {
+            self::assertArrayHasKey('status', $action['plan']);
+            self::assertIsString($action['plan']['status']);
             if ((bool) $action['is_optimal']) {
                 self::assertArrayNotHasKey('cost_of_deviation', $action);
             } else {


### PR DESCRIPTION
## Summary
- Preserve generated plan status in DebtSimulationService so metadata enhancements don't drop it
- Include plan status in DebtController responses
- Add feature coverage asserting proposed_actions contain status

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpstan analyse --memory-limit=512M app/Modules/AI/Simulations/DebtSimulationService.php app/Api/V1/Controllers/Simulations/DebtController.php tests/Feature/DebtSimulationApiTest.php`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpunit tests/Feature/DebtSimulationApiTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68a0bcabd0e88326abd4b0f7d74c29ea