### PR TITLE
feat(polymarket): fetch clarification events

### DIFF
--- a/fe/data/polymarket/etl.py
+++ b/fe/data/polymarket/etl.py
@@ -79,6 +79,17 @@ def fetch_order_book(market_id: str) -> Dict[str, Any]:
         return {}
 
 
+def fetch_clarification_resolution_events(market_id: str) -> List[Dict[str, Any]]:
+    """Return clarification/resolution events for a market."""
+    try:
+        return _get(
+            f"{BASE_URL}/clarification/resolution-events",
+            {"market": market_id},
+        )
+    except Exception:
+        return []
+
+
 def save_market(market: Dict[str, Any]) -> None:
     event = market.get("events", [{}])[0]
     event_date_str = event.get("endDate") or market.get("endDate")
@@ -95,6 +106,9 @@ def save_market(market: Dict[str, Any]) -> None:
         "market": market,
         "price_history": fetch_price_history(market["id"]),
         "order_book": fetch_order_book(market["id"]),
+        "clarification_resolution_events": fetch_clarification_resolution_events(
+            market["id"]
+        ),
         "resolution": {
             "description": market.get("resolutionDescription"),
             "sources": market.get("resolutionSources"),

--- a/fe/data/polymarket/schemas.py
+++ b/fe/data/polymarket/schemas.py
@@ -70,3 +70,14 @@ class ResolutionEvent(BaseModel):
     outcome: Optional[str] = Field(None, description="Winning outcome, if any")
     event_date: date = Field(..., description="Event date used for partitioning")
     category: str = Field(..., description="Market category used for partitioning")
+
+
+class ClarificationResolutionEvent(BaseModel):
+    """Clarification or resolution event for a market."""
+
+    market_id: str = Field(..., description="Polymarket market identifier")
+    timestamp: datetime = Field(..., description="Timestamp of the event")
+    event_type: str = Field(..., description="Type of event: clarification or resolution")
+    message: str = Field(..., description="Event message")
+    event_date: date = Field(..., description="Event date used for partitioning")
+    category: str = Field(..., description="Market category used for partitioning")

--- a/tests/python/test_polymarket_events.py
+++ b/tests/python/test_polymarket_events.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import json  # noqa: E402
+import pandas as pd  # noqa: E402
+from fe.data.polymarket import etl  # noqa: E402
+
+
+def test_save_market_writes_clarification_events(tmp_path, monkeypatch):
+    market = {
+        "id": "123",
+        "endDate": "2020-11-04T00:00:00Z",
+        "category": "politics",
+    }
+
+    events_payload = [
+        {
+            "id": 1,
+            "timestamp": "2020-11-05T00:00:00Z",
+            "type": "resolution",
+            "message": "resolved",
+        }
+    ]
+
+    def fake_get(url, params=None):
+        if "clarification/resolution-events" in url:
+            assert params == {"market": "123"}
+            return events_payload
+        if url.endswith("/trades"):
+            return []
+        if url.endswith("/book"):
+            return {}
+        raise AssertionError(f"unexpected url {url}")
+
+    monkeypatch.setattr(etl, "_get", fake_get)
+    monkeypatch.setattr(etl, "OUTPUT_DIR", tmp_path)
+
+    etl.save_market(market)
+
+    out_dir = tmp_path / "event_date=2020-11-04" / "category=politics"
+    parquet_files = list(out_dir.glob("market_123.parquet"))
+    assert parquet_files
+
+    df = pd.read_parquet(parquet_files[0])
+    record = df["data"].map(json.loads).iloc[0]
+    assert record["clarification_resolution_events"] == events_payload


### PR DESCRIPTION
## Summary
- add client for Polymarket clarification/resolution events
- capture clarification events when saving markets
- model clarification/resolution events in schemas
- test that events are persisted to Parquet

## Testing
- `flake8 --max-line-length=120 fe/data/polymarket/etl.py fe/data/polymarket/schemas.py tests/python/test_polymarket_events.py`
- `pytest tests/python/test_polymarket_events.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0bcab02208326be276b5206519bf5