### PR TITLE
Enhance rule objectivity heuristics

### DIFF
--- a/fe/features/rule_objectivity.py
+++ b/fe/features/rule_objectivity.py
@@ -7,11 +7,15 @@ import re
 CLEAR_KEYWORDS = {
     "official",
     "exact",
+    "exactly",
     "no later than",
     "based on",
     "publicly",
     "will be",
     "determined by",
+    "shall",
+    "must",
+    "within",
 }
 AMBIGUOUS_KEYWORDS = {
     "ambiguity",
@@ -25,7 +29,22 @@ AMBIGUOUS_KEYWORDS = {
     "subject to",
     "admin",
     "committee",
+    "approximately",
+    "approx",
+    "around",
+    "roughly",
+    "likely",
+    "probably",
 }
+
+CLEAR_PATTERNS = [
+    re.compile(r"within\s+\d+\s+(?:day|hour|minute|week|month)s?"),
+]
+
+AMBIGUOUS_PATTERNS = [
+    re.compile(r"\bapprox(?:\.|imately)?\b"),
+    re.compile(r"\broughly\b"),
+]
 
 
 def score_rule_objectivity(rule: Optional[str]) -> str:
@@ -40,9 +59,13 @@ def score_rule_objectivity(rule: Optional[str]) -> str:
     if not rule or not rule.strip():
         return "unknown"
 
-    text = rule.lower()
-    ambiguous = any(kw in text for kw in AMBIGUOUS_KEYWORDS)
-    clear = any(kw in text for kw in CLEAR_KEYWORDS)
+    text = " ".join(rule.split()).lower()
+    ambiguous = any(kw in text for kw in AMBIGUOUS_KEYWORDS) or any(
+        pattern.search(text) for pattern in AMBIGUOUS_PATTERNS
+    )
+    clear = any(kw in text for kw in CLEAR_KEYWORDS) or any(
+        pattern.search(text) for pattern in CLEAR_PATTERNS
+    )
     if re.search(r"\d", text):
         clear = True
 

--- a/tests/unit/features/test_rule_objectivity.py
+++ b/tests/unit/features/test_rule_objectivity.py
@@ -1,0 +1,37 @@
+from fe.features.rule_objectivity import score_rule_objectivity
+
+
+def test_none_returns_unknown():
+    assert score_rule_objectivity(None) == "unknown"
+
+
+def test_empty_returns_unknown():
+    assert score_rule_objectivity("   ") == "unknown"
+
+
+def test_clear_keyword_detection():
+    rule = "Official result will be determined by data"
+    assert score_rule_objectivity(rule) == "clear"
+
+
+def test_ambiguous_keyword_detection():
+    rule = "Outcome may be decided by admin"
+    assert score_rule_objectivity(rule) == "ambiguous"
+
+
+def test_digit_indicates_clear():
+    assert score_rule_objectivity("Payout will be 10 dollars") == "clear"
+
+
+def test_whitespace_normalisation():
+    rule = "Outcome will be resolved no     later    than   Jan 1"
+    assert score_rule_objectivity(rule) == "clear"
+
+
+def test_regex_ambiguous_detection():
+    assert score_rule_objectivity("Result is approximately 10") == "ambiguous"
+
+
+def test_regex_clear_detection():
+    rule = "Event shall settle within 5 days"
+    assert score_rule_objectivity(rule) == "clear"


### PR DESCRIPTION
## Summary
- refine clarity and ambiguity detection by normalizing whitespace, expanding keyword lists, and adding regex patterns
- add unit tests covering ambiguity, clarity, numeric detection, and whitespace edge cases

## Testing
- `flake8 fe/features/rule_objectivity.py tests/unit/features/test_rule_objectivity.py`
- `PYTHONPATH=. pytest tests/unit/features/test_rule_objectivity.py tests/python`


------
https://chatgpt.com/codex/tasks/task_e_68a0ca95253c83269dcfe4feb1cc73ba