### PR TITLE
Handle timezone mismatch in time_to_deadline

### DIFF
--- a/fe/features/time_to_deadline.py
+++ b/fe/features/time_to_deadline.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 
@@ -15,10 +15,36 @@ def time_to_deadline(
     Positive values indicate the deadline is in the future while negative
     values indicate it has already passed.  If ``deadline`` is ``None`` a
     ``NaN`` value is returned.
+
+    ``deadline`` and ``now`` may be naive or timezone-aware.  If their
+    timezone awareness differs, the naive datetime is assumed to be in
+    UTC.  Both values are converted to UTC before the calculation.
     """
     if deadline is None:
         return float("nan")
     if now is None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
+
+    def is_naive(dt: datetime) -> bool:
+        return dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None
+
+    deadline_is_naive = is_naive(deadline)
+    now_is_naive = is_naive(now)
+
+    if deadline_is_naive != now_is_naive:
+        if deadline_is_naive:
+            deadline = deadline.replace(tzinfo=timezone.utc)
+            now = now.astimezone(timezone.utc)
+        else:
+            deadline = deadline.astimezone(timezone.utc)
+            now = now.replace(tzinfo=timezone.utc)
+    else:
+        if deadline_is_naive:
+            deadline = deadline.replace(tzinfo=timezone.utc)
+            now = now.replace(tzinfo=timezone.utc)
+        else:
+            deadline = deadline.astimezone(timezone.utc)
+            now = now.astimezone(timezone.utc)
+
     delta = deadline - now
     return delta.total_seconds() / 86400

--- a/tests/unit/features/test_time_to_deadline.py
+++ b/tests/unit/features/test_time_to_deadline.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+from fe.features.time_to_deadline import time_to_deadline  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "deadline, now",
+    [
+        (datetime(2024, 1, 2, tzinfo=timezone.utc), datetime(2024, 1, 1)),
+        (datetime(2024, 1, 2), datetime(2024, 1, 1, tzinfo=timezone.utc)),
+    ],
+)
+def test_naive_and_aware_inputs(deadline, now):
+    result = time_to_deadline(deadline, now)
+    assert result == pytest.approx(1)


### PR DESCRIPTION
## Summary
- Normalize naive and aware datetimes to UTC in `time_to_deadline`
- Document timezone handling in `time_to_deadline` docstring
- Test naive vs aware combinations for `time_to_deadline`

## Testing
- `flake8 fe/features/time_to_deadline.py tests/unit/features/test_time_to_deadline.py`
- `pytest tests/fe/test_time_to_deadline.py -q`
- `pytest tests/unit/features/test_time_to_deadline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ca944c3883269e142f5540003225