### PR TITLE
test: add balanced strategy weighted round robin test

### DIFF
--- a/tests/unit/Modules/AI/BalancedStrategyTest.php
+++ b/tests/unit/Modules/AI/BalancedStrategyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\unit\Modules\AI;
+
+use FireflyIII\Modules\AI\Simulations\Strategies\BalancedStrategy;
+use Tests\integration\TestCase;
+
+/**
+ * @group unit-test
+ * @group ai
+ */
+final class BalancedStrategyTest extends TestCase
+{
+    public function testWeightedRoundRobinAcrossMultipleDebts(): void
+    {
+        $strategy = new BalancedStrategy();
+
+        $debts = [
+            ['balance' => 1000.0],
+            ['balance' => 500.0],
+            ['balance' => 250.0],
+        ];
+
+        $sequence = [];
+        for ($i = 0; $i < 7; $i++) {
+            $sequence[] = $strategy->selectTargetDebt($debts);
+        }
+
+        self::assertSame([0, 1, 0, 2, 0, 1, 0], $sequence);
+
+        $strategy = new BalancedStrategy();
+
+        $counts = [0, 0, 0];
+        for ($i = 0; $i < 700; $i++) {
+            $index = $strategy->selectTargetDebt($debts);
+            $counts[$index]++;
+        }
+
+        self::assertSame(400, $counts[0]);
+        self::assertSame(200, $counts[1]);
+        self::assertSame(100, $counts[2]);
+    }
+}


### PR DESCRIPTION
## Summary
- test BalancedStrategy distributes extra payments via weighted round-robin sequence and ratios
- ensure long-term ratio check starts from fresh strategy instance to isolate test

## Testing
- `APP_KEY=base64:0000000000000000000000000000000000000000000 vendor/bin/phpstan analyse tests/unit/Modules/AI/BalancedStrategyTest.php -c .ci/phpstan.neon`
- `APP_KEY=base64:0000000000000000000000000000000000000000000 vendor/bin/phpunit --no-coverage tests/unit/Modules/AI/BalancedStrategyTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0d448259c832688ccb2ba67b031a9