### PR TITLE
Flush debt simulation cache on account changes

### DIFF
--- a/app/Listeners/FlushDebtSimulationCache.php
+++ b/app/Listeners/FlushDebtSimulationCache.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FireflyIII\Listeners;
+
+use FireflyIII\Models\Account;
+use FireflyIII\Support\Cache\UserScopedCache;
+
+/**
+ * Flushes the user scoped cache for debt simulations when an account changes.
+ */
+class FlushDebtSimulationCache
+{
+    public function handle(Account $account): void
+    {
+        UserScopedCache::flush(
+            (string) $account->user_id,
+            $account->user_group_id === null ? null : (string) $account->user_group_id,
+        );
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -59,6 +59,7 @@ use FireflyIII\Events\UpdatedAccount;
 use FireflyIII\Events\UpdatedTransactionGroup;
 use FireflyIII\Events\UserChangedEmail;
 use FireflyIII\Events\WarnUserAboutBill;
+use FireflyIII\Listeners\FlushDebtSimulationCache;
 use FireflyIII\Handlers\Observer\AccountObserver;
 use FireflyIII\Handlers\Observer\AttachmentObserver;
 use FireflyIII\Handlers\Observer\AutoBudgetObserver;
@@ -196,6 +197,12 @@ class EventServiceProvider extends ServiceProvider
             ],
             UpdatedAccount::class                  => [
                 'FireflyIII\Handlers\Events\UpdatedAccountEventHandler@recalculateCredit',
+            ],
+            'eloquent.updated: FireflyIII\Models\Account' => [
+                FlushDebtSimulationCache::class,
+            ],
+            'eloquent.deleted: FireflyIII\Models\Account' => [
+                FlushDebtSimulationCache::class,
             ],
 
             // bill related events:

--- a/tests/integration/AI/DebtSimulationCacheInvalidationTest.php
+++ b/tests/integration/AI/DebtSimulationCacheInvalidationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\integration\AI;
+
+use FireflyIII\Models\Account;
+use FireflyIII\Support\Cache\UserScopedCache;
+use Illuminate\Support\Facades\Cache;
+use Tests\integration\TestCase;
+
+/**
+ * @group integration-test
+ * @group ai
+ *
+ * @internal
+ */
+final class DebtSimulationCacheInvalidationTest extends TestCase
+{
+    public function testFlushesCacheOnAccountUpdated(): void
+    {
+        Cache::flush();
+        $account = new Account(['user_id' => 1, 'user_group_id' => 1]);
+
+        UserScopedCache::remember('1', '1', 'debt-sim-test', fn() => 'cached', 3600);
+        $key = 'u:1:g:1:debt-sim-test';
+        self::assertTrue(Cache::has($key));
+
+        event('eloquent.updated: ' . Account::class, $account);
+
+        self::assertFalse(Cache::has($key));
+    }
+
+    public function testFlushesCacheOnAccountDeleted(): void
+    {
+        Cache::flush();
+        $account = new Account(['user_id' => 1, 'user_group_id' => 1]);
+
+        UserScopedCache::remember('1', '1', 'debt-sim-test', fn() => 'cached', 3600);
+        $key = 'u:1:g:1:debt-sim-test';
+        self::assertTrue(Cache::has($key));
+
+        event('eloquent.deleted: ' . Account::class, $account);
+
+        self::assertFalse(Cache::has($key));
+    }
+}


### PR DESCRIPTION
## Summary
- add FlushDebtSimulationCache listener
- hook listener into account update/delete events
- test debt simulation cache invalidation on account changes

## Testing
- `APP_KEY=TestTestTestTestTestTestTestTest composer unit-test`
- `APP_KEY=TestTestTestTestTestTestTestTest vendor/bin/phpunit tests/integration/AI/DebtSimulationCacheInvalidationTest.php`
- `APP_KEY=TestTestTestTestTestTestTestTest composer integration-test` *(fails: Invalid key supplied)*
- `APP_KEY=TestTestTestTestTestTestTestTest vendor/bin/phpstan analyse --memory-limit=1G app/Listeners/FlushDebtSimulationCache.php app/Providers/EventServiceProvider.php tests/integration/AI/DebtSimulationCacheInvalidationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0d447422483269e469a8b6935115a