### PR TITLE
test: verify interest saved and deviation metrics

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -118,8 +118,6 @@ class DebtSimulationService
 
                 $bestInterest  = $plans[0]['total_interest'] ?? 0.0;
                 $bestMonths    = $plans[0]['months'] ?? 0;
-                $interestList  = array_column($plans, 'total_interest');
-                $worstInterest = $interestList !== [] ? max($interestList) : 0.0;
 
                 foreach ($plans as $i => &$plan) {
                     // Preserve the original status in case additional metrics overwrite keys.
@@ -128,7 +126,7 @@ class DebtSimulationService
                     $plan['rank']                  = $i + 1;
                     $plan['is_optimal']            = 0 === $i;
                     $plan['total_interest']        = (float) $plan['total_interest'];
-                    $plan['interest_saved']        = $worstInterest - $plan['total_interest'];
+                    $plan['interest_saved']        = $bestInterest - $plan['total_interest'];
                     $plan['time_to_payoff_months'] = $plan['months'];
                     $plan['cost_of_deviation']     = [
                         'currency'    => $plan['total_interest'] - $bestInterest,

--- a/tests/unit/DebtSimulationTest.php
+++ b/tests/unit/DebtSimulationTest.php
@@ -104,11 +104,11 @@ final class DebtSimulationTest extends TestCase
         self::assertFalse($mapped['snowball']['is_optimal']);
         self::assertFalse($mapped['balanced']['is_optimal']);
 
-        self::assertEqualsWithDelta(7.0831535569, $mapped['avalanche']['interest_saved'], 0.0001);
-        self::assertEqualsWithDelta(0.0, $mapped['snowball']['interest_saved'], 0.0001);
+        self::assertEqualsWithDelta(0.0, $mapped['avalanche']['interest_saved'], 0.0001);
+        self::assertEqualsWithDelta(-7.0831535569, $mapped['snowball']['interest_saved'], 0.0001);
 
-        self::assertEqualsWithDelta(7.0831535569, $mapped['snowball']['cost_of_deviation']['currency'], 0.0001);
         self::assertEqualsWithDelta(0.0, $mapped['avalanche']['cost_of_deviation']['currency'], 0.0001);
+        self::assertEqualsWithDelta(7.0831535569, $mapped['snowball']['cost_of_deviation']['currency'], 0.0001);
         self::assertEquals(0, $mapped['avalanche']['cost_of_deviation']['time_months']);
         self::assertEquals(0, $mapped['snowball']['cost_of_deviation']['time_months']);
 

--- a/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
@@ -39,9 +39,11 @@ final class DebtSimulationServiceRankingTest extends TestCase
         $bestMonths   = $plans[0]['months'];
 
         foreach ($plans as $plan) {
-            $expectedCurrency = $plan['total_interest'] - $bestInterest;
-            $expectedMonths   = $plan['months'] - $bestMonths;
+            $expectedCurrency      = $plan['total_interest'] - $bestInterest;
+            $expectedMonths        = $plan['months'] - $bestMonths;
+            $expectedInterestSaved = $bestInterest - $plan['total_interest'];
 
+            self::assertEqualsWithDelta($expectedInterestSaved, $plan['interest_saved'], 0.0001);
             self::assertEqualsWithDelta($expectedCurrency, $plan['cost_of_deviation']['currency'], 0.0001);
             self::assertEquals($expectedMonths, $plan['cost_of_deviation']['time_months']);
 


### PR DESCRIPTION
## Summary
- compute `interest_saved` relative to the optimal plan
- validate `interest_saved` and deviation metrics in ranking tests
- adjust debt simulation tests for new metric semantics

## Testing
- `composer unit-test`
- `APP_KEY=base64:0000000000000000000000000000000000000000000= ./vendor/bin/phpstan analyse -c .ci/phpstan.neon --memory-limit=1G --no-progress` *(fails: Found 485 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a490c937a88326b9b495f07621f2e6