### PR TITLE
feat: compute interest savings after sorting

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -129,14 +129,14 @@ class DebtSimulationService
                     $plan['interest_saved']        = $bestInterest - $plan['total_interest'];
                     $plan['time_to_payoff_months'] = $plan['months'];
                     $plan['cost_of_deviation']     = [
-                        'currency'    => $plan['total_interest'] - $bestInterest,
+                        'currency'    => -$plan['interest_saved'],
                         'time_months' => $plan['months'] - $bestMonths,
                     ];
 
                     $tradeoffString = $plan['is_optimal']
                         ? 'no tradeoffs'
                         : sprintf(
-                            '%.2f extra interest and %d more months',
+                            'loses %.2f in interest savings and %d more months',
                             $plan['cost_of_deviation']['currency'],
                             $plan['cost_of_deviation']['time_months']
                         );
@@ -145,7 +145,7 @@ class DebtSimulationService
                         $plan['meta'],
                         [
                             'ranking_heuristic' => self::RANKING_HEURISTIC,
-                            'ranking_reason'    => $plan['is_optimal'] ? 'minimizes interest' : 'higher cost or duration',
+                            'ranking_reason'    => $plan['is_optimal'] ? 'maximizes interest savings' : 'less interest saved or longer duration',
                             'tradeoffs'         => $tradeoffString,
                         ]
                     );

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -77,7 +77,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
         ]
       },
       "metrics": {
-        "interest_saved": 61.88,
+        "interest_saved": 0,
         "time_to_payoff_months": 34,
         "total_interest_paid": 516.09,
         "monthly_cash_flow": [
@@ -112,7 +112,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
         ]
       },
       "metrics": {
-        "interest_saved": 0,
+        "interest_saved": -61.88,
         "time_to_payoff_months": 36,
         "total_interest_paid": 577.97,
         "monthly_cash_flow": [
@@ -143,7 +143,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
     - `strategy` – Name of the heuristic applied (`avalanche`, `snowball` or `balanced`).
     - `schedule` – Monthly breakdown of payments, balances, interest and cash flow.
   - `metrics` – Aggregated plan results:
-    - `interest_saved` – Interest saved compared to the worst plan.
+    - `interest_saved` – Interest saved compared to the optimal plan (negative values indicate extra interest).
     - `time_to_payoff_months` – Number of months to clear all debts.
     - `total_interest_paid` – Total interest paid over the lifetime of the plan.
     - `monthly_cash_flow` – Remaining budget for each month.
@@ -154,7 +154,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
     - `strategy_explanation` – Description of how the payoff strategy works.
     - `ranking_heuristic` – Ranking algorithm applied to the plans.
     - `ranking_reason` – Explanation of why the plan received its rank.
-    - `tradeoffs` – Summary of extra cost and time versus the optimal plan.
+    - `tradeoffs` – Summary of lost interest savings and extra time versus the optimal plan.
 
 ## Heuristics
 


### PR DESCRIPTION
## Summary
- compute `interest_saved` relative to the best plan and expose lost savings
- update tradeoff messaging and ranking details to emphasize interest savings
- clarify debt simulation docs for new `interest_saved` behavior

## Testing
- `composer unit-test`
- `./vendor/bin/phpstan analyse --no-progress --memory-limit=1G app/Modules/AI/Simulations/DebtSimulationService.php`


------
https://chatgpt.com/codex/tasks/task_e_68a490c862848326b6e8ca0b07ce7177