### PR TITLE
Add Brier score evaluation test

### DIFF
--- a/tests/fe/base_rates/test_estimator.py
+++ b/tests/fe/base_rates/test_estimator.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from fe.base_rates import evaluate_brier_score  # noqa: E402
+import fe.base_rates.estimator as estimator  # noqa: E402
+
+
+def test_historical_brier_score_improves_over_baseline():
+    estimator._DATA = None
+    estimator._MODELS = {}
+    _, improvement = evaluate_brier_score(random_state=1)
+    assert improvement > 0


### PR DESCRIPTION
## Summary
- add unit test ensuring `evaluate_brier_score` improves over a 0.5 baseline when using bundled historical data

## Testing
- `flake8 tests/fe/base_rates/test_estimator.py`
- `pytest tests/fe/base_rates/test_estimator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5d46976a4832691e7e48671d1e60a