### PR TITLE
Add BalancedStrategy tests for proportional allocation and reset

### DIFF
--- a/tests/unit/strategies/BalancedStrategyTest.php
+++ b/tests/unit/strategies/BalancedStrategyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\unit\strategies;
+
+use FireflyIII\Modules\AI\Simulations\Strategies\BalancedStrategy;
+use Tests\integration\TestCase;
+
+/**
+ * @group unit-test
+ * @group ai
+ */
+final class BalancedStrategyTest extends TestCase
+{
+    public function testProportionalAllocation(): void
+    {
+        $strategy = new BalancedStrategy();
+
+        $debts = [
+            ['balance' => 1000.0],
+            ['balance' => 500.0],
+        ];
+
+        $counts = [0, 0];
+        for ($i = 0; $i < 300; $i++) {
+            $index = $strategy->selectTargetDebt($debts);
+            $counts[$index]++;
+        }
+
+        self::assertSame(200, $counts[0]);
+        self::assertSame(100, $counts[1]);
+    }
+
+    public function testResetClearsCache(): void
+    {
+        $strategy = new BalancedStrategy();
+
+        $debts = [
+            ['balance' => 1000.0],
+            ['balance' => 500.0],
+        ];
+
+        self::assertSame(0, $strategy->selectTargetDebt($debts));
+        self::assertSame(1, $strategy->selectTargetDebt($debts));
+
+        $strategy->reset();
+
+        self::assertSame(0, $strategy->selectTargetDebt($debts));
+    }
+}


### PR DESCRIPTION
## Summary
- add BalancedStrategy unit test ensuring proportional allocation of extra payments
- verify BalancedStrategy reset clears internal weights

## Testing
- `composer unit-test`
- `APP_KEY=base64:oPIU1uNU809Eker4ild3d0ku8oWaNAUV495eV66ooj4= ./vendor/bin/phpstan analyse -c .ci/phpstan.neon tests/unit/strategies/BalancedStrategyTest.php --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_68a7291460ec83268f080d2a24996764