### PR TITLE
Expose heuristic metrics and trade-off drivers in debt simulations

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -114,7 +114,7 @@ class DebtSimulationService
                     $plans[] = array_merge(
                         [
                             'strategy' => $strategy->getName(),
-                            'meta'     => ['strategy_explanation' => $strategy->getDescription()],
+                            'meta'     => ['strategy_explanation' => $strategy->getExplanation()],
                         ],
                         $plan
                     );
@@ -161,7 +161,14 @@ class DebtSimulationService
                         $plan['meta'],
                         [
                             'ranking_heuristic' => self::RANKING_HEURISTIC,
-                            'ranking_reason'    => $plan['is_optimal'] ? 'maximizes interest savings' : 'less interest saved or longer duration',
+                            'heuristic_scores'  => [
+                                'total_interest' => $plan['total_interest'],
+                                'months'         => $plan['months'],
+                            ],
+                            'tradeoff_drivers'  => $plan['cost_of_deviation'],
+                            'ranking_reason'    => $plan['is_optimal']
+                                ? 'maximizes interest savings'
+                                : 'less interest saved or longer duration',
                             'tradeoffs'         => $tradeoffString,
                         ]
                     );

--- a/app/Modules/AI/Simulations/Strategies/AvalancheStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/AvalancheStrategy.php
@@ -11,7 +11,7 @@ class AvalancheStrategy implements StrategyInterface
         return 'avalanche';
     }
 
-    public function getDescription(): string
+    public function getExplanation(): string
     {
         return 'Pays extra toward the debt with the highest interest rate first.';
     }

--- a/app/Modules/AI/Simulations/Strategies/BalancedStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/BalancedStrategy.php
@@ -30,7 +30,7 @@ class BalancedStrategy implements StrategyInterface
         return 'balanced';
     }
 
-    public function getDescription(): string
+    public function getExplanation(): string
     {
         return 'Distributes extra payments proportionally based on each debt\'s remaining balance.';
     }

--- a/app/Modules/AI/Simulations/Strategies/SnowballStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/SnowballStrategy.php
@@ -11,7 +11,7 @@ class SnowballStrategy implements StrategyInterface
         return 'snowball';
     }
 
-    public function getDescription(): string
+    public function getExplanation(): string
     {
         return 'Pays extra toward the debt with the smallest balance first to build momentum.';
     }

--- a/app/Modules/AI/Simulations/Strategies/StrategyInterface.php
+++ b/app/Modules/AI/Simulations/Strategies/StrategyInterface.php
@@ -11,7 +11,7 @@ interface StrategyInterface
     /**
      * Human-readable explanation of how the strategy allocates extra payments.
      */
-    public function getDescription(): string;
+    public function getExplanation(): string;
 
     /** Reset any internal state before simulating a new schedule. */
     public function reset(): void;

--- a/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
@@ -52,6 +52,12 @@ final class DebtSimulationServiceRankingTest extends TestCase
             self::assertSame(DebtSimulationService::RANKING_HEURISTIC, $plan['meta']['ranking_heuristic']);
             self::assertIsString($plan['meta']['ranking_reason']);
             self::assertIsString($plan['meta']['tradeoffs']);
+            self::assertIsArray($plan['meta']['heuristic_scores']);
+            self::assertArrayHasKey('total_interest', $plan['meta']['heuristic_scores']);
+            self::assertArrayHasKey('months', $plan['meta']['heuristic_scores']);
+            self::assertIsArray($plan['meta']['tradeoff_drivers']);
+            self::assertArrayHasKey('currency', $plan['meta']['tradeoff_drivers']);
+            self::assertArrayHasKey('time_months', $plan['meta']['tradeoff_drivers']);
         }
     }
 


### PR DESCRIPTION
## Summary
- Provide `getExplanation()` on payoff strategies
- Surface heuristic scores and trade-off drivers in debt simulation results
- Assert new metadata in ranking unit test

## Testing
- `APP_KEY=base64:0000000000000000000000000000000000000000000 vendor/bin/phpstan analyse --memory-limit=512M app/Modules/AI/Simulations tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php`
- `APP_KEY=base64:0000000000000000000000000000000000000000000 vendor/bin/phpunit tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68a72913b4a88326b5fa4d603fb05631