### PR TITLE
Add shuffled-label significance to backtest metrics

### DIFF
--- a/fe/strategies/backtest.py
+++ b/fe/strategies/backtest.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from itertools import product
 from typing import Callable, Dict, Iterable, Sequence
 
+import numpy as np
+
 import pandas as pd
 
 
@@ -42,11 +44,46 @@ def _simulate(
     return returns
 
 
+def _compute_metrics(
+    returns: pd.Series,
+    n_shuffles: int,
+    rng: np.random.Generator | None,
+) -> tuple[float, float, float, float]:
+    """Return cumulative performance metrics for ``returns``.
+
+    The p-value is computed via a shuffled-label significance test where the
+    order of returns is randomly permuted ``n_shuffles`` times.  The proportion
+    of shuffled outcomes with a final return greater than or equal to the
+    observed return forms a one-sided p-value.
+    """
+
+    total_return = (1.0 + returns).prod() - 1.0
+    sharpe = 0.0
+    if returns.std() > 0:
+        sharpe = returns.mean() / returns.std() * np.sqrt(252)
+    equity = (1.0 + returns).cumprod()
+    mdd = (equity / equity.cummax() - 1).min()
+
+    p_value = float("nan")
+    if n_shuffles > 0 and rng is not None:
+        shuffled = []
+        arr = returns.to_numpy()
+        for _ in range(n_shuffles):
+            sh_ret = rng.permutation(arr)
+            shuffled.append((1.0 + sh_ret).prod() - 1.0)
+        sh_arr = np.asarray(shuffled)
+        p_value = (np.sum(sh_arr >= total_return) + 1) / (n_shuffles + 1)
+
+    return float(total_return), float(sharpe), float(mdd), float(p_value)
+
+
 def run_backtest(
     strategy: Callable[..., pd.Series],
     data: pd.DataFrame,
     params: Dict[str, Sequence],
     slippage: float = 0.0,
+    n_shuffles: int = 0,
+    seed: int | None = None,
 ) -> pd.DataFrame:
     """Run a strategy over a grid of parameters.
 
@@ -61,13 +98,17 @@ def run_backtest(
         Mapping from parameter name to a sequence of values to search.
     slippage:
         Fractional slippage cost applied to position changes.
+    n_shuffles:
+        Number of shuffled-label trials used to compute the p-value.
+    seed:
+        Optional seed for the random number generator used in shuffling.
 
     Returns
     -------
     pd.DataFrame
         DataFrame where each row corresponds to a parameter combination
-        with an additional ``return`` column containing the cumulative
-        return over the run.
+        with additional performance columns ``return``, ``sharpe``,
+        ``max_drawdown`` and ``p_value``.
     """
     if "price" not in data.columns:
         raise ValueError("data must contain a 'price' column")
@@ -76,12 +117,23 @@ def run_backtest(
     grid: Iterable[Sequence] = product(*params.values()) if names else [()]
 
     results = []
+    rng = np.random.default_rng(seed) if n_shuffles > 0 else None
     for combo in grid:
         kwargs = dict(zip(names, combo))
         positions = strategy(data, **kwargs)
         returns = _simulate(data["price"], positions, slippage)
-        total_return = (1.0 + returns).prod() - 1.0
-        results.append({**kwargs, "return": total_return})
+        total_return, sharpe, mdd, p_value = _compute_metrics(
+            returns, n_shuffles, rng
+        )
+        results.append(
+            {
+                **kwargs,
+                "return": total_return,
+                "sharpe": sharpe,
+                "max_drawdown": mdd,
+                "p_value": p_value,
+            }
+        )
 
     return pd.DataFrame(results)
 

--- a/tests/python/test_backtest.py
+++ b/tests/python/test_backtest.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-import pandas as pd
-import pytest
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
 
-from fe.strategies import run_backtest
+from fe.strategies import run_backtest  # noqa: E402
 
 
 def buy_and_hold(_data):
@@ -20,9 +20,13 @@ def threshold_strategy(data, threshold):
 
 def test_run_backtest_buy_and_hold():
     df = pd.DataFrame({"price": [1.0, 1.1, 1.2]})
-    result = run_backtest(buy_and_hold, df, {})
+    result = run_backtest(buy_and_hold, df, {}, n_shuffles=10, seed=0)
     assert result.shape[0] == 1
-    assert result["return"].iloc[0] == pytest.approx(0.2, rel=1e-9)
+    row = result.iloc[0]
+    assert row["return"] == pytest.approx(0.2, rel=1e-9)
+    assert {"sharpe", "max_drawdown", "p_value"}.issubset(result.columns)
+    assert row["max_drawdown"] == pytest.approx(0.0, abs=1e-12)
+    assert 0 <= row["p_value"] <= 1
 
 
 def test_slippage_and_grid_search():
@@ -31,6 +35,10 @@ def test_slippage_and_grid_search():
     grid = run_backtest(threshold_strategy, df, params, slippage=0.0)
     assert set(grid["threshold"]) == {0.0, 0.05}
 
-    no_slip = run_backtest(threshold_strategy, df, {"threshold": [0.0]}, slippage=0.0)
-    with_slip = run_backtest(threshold_strategy, df, {"threshold": [0.0]}, slippage=0.01)
+    no_slip = run_backtest(
+        threshold_strategy, df, {"threshold": [0.0]}, slippage=0.0
+    )
+    with_slip = run_backtest(
+        threshold_strategy, df, {"threshold": [0.0]}, slippage=0.01
+    )
     assert with_slip["return"].iloc[0] < no_slip["return"].iloc[0]

--- a/tests/unit/strategies/test_backtest_pipeline.py
+++ b/tests/unit/strategies/test_backtest_pipeline.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from fe.strategies import walk_forward  # noqa: E402
+from fe.strategies import run_backtest, walk_forward  # noqa: E402
 
 
 def buy_and_hold(_data):
@@ -37,3 +37,18 @@ def test_walk_forward_windowing_and_aggregation():
         running *= 1 + r
         cumulative.append(running - 1)
     assert result["cumulative"].tolist() == pytest.approx(cumulative, rel=1e-9)
+
+
+def test_run_backtest_metrics():
+    df = pd.DataFrame({"price": [1.0, 1.2, 1.1, 1.3]})
+    result = run_backtest(buy_and_hold, df, {}, n_shuffles=10, seed=0)
+    assert {
+        "return",
+        "sharpe",
+        "max_drawdown",
+        "p_value",
+    }.issubset(result.columns)
+    row = result.iloc[0]
+    assert row["return"] == pytest.approx(0.3, rel=1e-9)
+    assert row["max_drawdown"] <= 0
+    assert 0 <= row["p_value"] <= 1


### PR DESCRIPTION
## Summary
- extend vectorized backtesting to compute Sharpe, max drawdown and shuffled-label p-values
- test backtest metrics and walk-forward aggregation

## Testing
- `flake8 fe/strategies/backtest.py tests/python/test_backtest.py tests/unit/strategies/test_backtest_pipeline.py`
- `pytest tests/python/test_backtest.py tests/unit/strategies/test_backtest_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada99c67348326894c00289c4caca4