### PR TITLE
Flush debt simulation cache on user deletion

### DIFF
--- a/app/Listeners/FlushDebtSimulationCache.php
+++ b/app/Listeners/FlushDebtSimulationCache.php
@@ -6,17 +6,18 @@ namespace FireflyIII\Listeners;
 
 use FireflyIII\Models\Account;
 use FireflyIII\Support\Cache\UserScopedCache;
+use FireflyIII\User;
 
 /**
- * Flushes the user scoped cache for debt simulations when an account changes.
+ * Flushes the user scoped cache for debt simulations when an account or user changes.
  */
 class FlushDebtSimulationCache
 {
-    public function handle(Account $account): void
+    public function handle(Account|User $model): void
     {
-        UserScopedCache::flush(
-            (string) $account->user_id,
-            $account->user_group_id === null ? null : (string) $account->user_group_id,
-        );
+        $userId  = $model instanceof Account ? (string) $model->user_id : (string) $model->id;
+        $groupId = $model->user_group_id === null ? null : (string) $model->user_group_id;
+
+        UserScopedCache::flush($userId, $groupId);
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -204,6 +204,9 @@ class EventServiceProvider extends ServiceProvider
             'eloquent.deleted: FireflyIII\Models\Account' => [
                 FlushDebtSimulationCache::class,
             ],
+            'eloquent.deleted: FireflyIII\User' => [
+                FlushDebtSimulationCache::class,
+            ],
 
             // bill related events:
             WarnUserAboutBill::class               => [

--- a/tests/integration/AI/DebtSimulationCacheInvalidationTest.php
+++ b/tests/integration/AI/DebtSimulationCacheInvalidationTest.php
@@ -6,6 +6,7 @@ namespace Tests\integration\AI;
 
 use FireflyIII\Models\Account;
 use FireflyIII\Support\Cache\UserScopedCache;
+use FireflyIII\User;
 use Illuminate\Support\Facades\Cache;
 use Tests\integration\TestCase;
 
@@ -41,6 +42,22 @@ final class DebtSimulationCacheInvalidationTest extends TestCase
         self::assertTrue(Cache::has($key));
 
         event('eloquent.deleted: ' . Account::class, $account);
+
+        self::assertFalse(Cache::has($key));
+    }
+
+    public function testFlushesCacheOnUserDeleted(): void
+    {
+        Cache::flush();
+        $user                 = new User();
+        $user->id             = 1;
+        $user->user_group_id  = 1;
+
+        UserScopedCache::remember('1', '1', 'debt-sim-test', fn() => 'cached', 3600);
+        $key = 'u:1:g:1:debt-sim-test';
+        self::assertTrue(Cache::has($key));
+
+        event('eloquent.deleted: ' . User::class, $user);
 
         self::assertFalse(Cache::has($key));
     }


### PR DESCRIPTION
## Summary
- Allow debt simulation cache flush for user models
- Handle user delete events for debt simulation cache
- Test cache invalidation when a user is removed

## Testing
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= vendor/bin/phpstan analyse app/Listeners/FlushDebtSimulationCache.php app/Providers/EventServiceProvider.php tests/integration/AI/DebtSimulationCacheInvalidationTest.php --memory-limit=1G`
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= vendor/bin/phpunit -c phpunit.xml tests/integration/AI/DebtSimulationCacheInvalidationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68af02fa0f3c8326aef9cc278ffbafba