### PR TITLE
Add integration tests for gate config and wheel installation

### DIFF
--- a/tests/export/test_wheel.py
+++ b/tests/export/test_wheel.py
@@ -8,8 +8,8 @@ import pandas as pd
 import pytest
 
 
-def test_wheel_dry_run_and_strategy_load() -> None:
-    """Install the built wheel in a dry-run and exercise a strategy."""
+def test_wheel_install_and_strategy_load(tmp_path: Path) -> None:
+    """Install the built wheel into a temporary env and exercise a strategy."""
 
     root = Path(__file__).resolve().parents[2]
     dist = root / "dist"
@@ -18,20 +18,22 @@ def test_wheel_dry_run_and_strategy_load() -> None:
         pytest.skip("No wheel built to test")
     wheel = wheels[0]
 
+    target = tmp_path / "site"
     subprocess.run(
         [
             sys.executable,
             "-m",
             "pip",
             "install",
-            "--dry-run",
             "--no-deps",
+            "--target",
+            str(target),
             str(wheel),
         ],
         check=True,
     )
 
-    sys.path.insert(0, str(wheel))
+    sys.path.insert(0, str(target))
     from fe.strategies.deadline_no import DeadlineNoStrategy
 
     df = pd.DataFrame(

--- a/tests/fe/signoff/test_gate.py
+++ b/tests/fe/signoff/test_gate.py
@@ -35,3 +35,22 @@ def test_gate_respects_config_file(tmp_path):
     cfg = tmp_path / "config.json"
     cfg.write_text(json.dumps({"MAX_MDD": 0.05}))
     assert not approve(report, config_path=cfg)
+
+
+def test_gate_uses_default_config():
+    root = Path(__file__).resolve().parents[3]
+    cfg = json.loads((root / "fe" / "signoff" / "config.json").read_text())
+
+    failing = {
+        "sample_size": cfg["MIN_SAMPLE"] - 1,
+        "max_drawdown": cfg["MAX_MDD"] + 0.01,
+        "p_value": cfg["ALPHA"] + 0.01,
+    }
+    assert not approve(failing)
+
+    passing = {
+        "sample_size": cfg["MIN_SAMPLE"],
+        "max_drawdown": cfg["MAX_MDD"],
+        "p_value": cfg["ALPHA"] - 0.01,
+    }
+    assert approve(passing)


### PR DESCRIPTION
## Summary
- add integration test verifying default gate thresholds from config.json
- install built wheel in temp env and import strategies during tests

## Testing
- `ruff check fe/signoff/gate.py tests/fe/signoff/test_gate.py tests/export/test_wheel.py`
- `pytest tests/fe/signoff/test_gate.py tests/export/test_wheel.py`

------
https://chatgpt.com/codex/tasks/task_e_68af02f98b4483268ea97f6cd5bd86b2