### PR TITLE
feat: expose refinance recommendations

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -71,6 +71,7 @@ class DebtController extends Controller
                     'plan'       => [
                         'strategy' => $plan['strategy'],
                         'schedule' => $plan['schedule'],
+                        'recommendations' => $plan['recommendations'] ?? [],
                         'status'   => $plan['status'],
                     ],
                     'metrics' => [

--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -203,11 +203,22 @@ class DebtSimulationService
             return $debt;
         }, $debts);
 
-        $schedule          = [];
-        $totalInterest     = 0.0;
-        $month             = 0;
-        $cashFlowTimeline  = [];
-        $nonConverging     = false;
+        $recommendations   = [];
+        foreach ($debts as $debt) {
+            if ($debt['rate'] >= 0.10) {
+                $recommendations[] = sprintf(
+                    'Consider refinancing %s to lower the %.2f%% APR.',
+                    $debt['name'],
+                    $debt['rate'] * 100
+                );
+            }
+        }
+
+        $schedule         = [];
+        $totalInterest    = 0.0;
+        $month            = 0;
+        $cashFlowTimeline = [];
+        $nonConverging    = false;
 
         $strategy->reset();
 
@@ -301,6 +312,7 @@ class DebtSimulationService
             'total_interest'    => $totalInterest,
             'months'            => $month,
             'monthly_cash_flow' => $cashFlowTimeline,
+            'recommendations'   => $recommendations,
             'status'            => $nonConverging ? 'non_converging' : 'ok',
         ];
     }

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -74,6 +74,9 @@ Simulation results are cached per user to speed up repeated requests. The cache 
             "cash_flow": 0
           }
 
+        ],
+        "recommendations": [
+          "Consider refinancing Loan1 to lower the 10.00% APR."
         ]
       },
       "metrics": {
@@ -109,6 +112,9 @@ Simulation results are cached per user to speed up repeated requests. The cache 
             "cash_flow": 0
           }
 
+        ],
+        "recommendations": [
+          "Consider refinancing Loan1 to lower the 10.00% APR."
         ]
       },
       "metrics": {
@@ -142,6 +148,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
   - `plan` – Detailed strategy output:
     - `strategy` – Name of the heuristic applied (`avalanche`, `snowball` or `balanced`).
     - `schedule` – Monthly breakdown of payments, balances, interest and cash flow.
+    - `recommendations` – Array of refinance suggestions derived from the input debts.
   - `metrics` – Aggregated plan results:
     - `interest_saved` – Interest saved compared to the optimal plan (negative values indicate extra interest).
     - `time_to_payoff_months` – Number of months to clear all debts.

--- a/tests/unit/DebtSimulationTest.php
+++ b/tests/unit/DebtSimulationTest.php
@@ -38,6 +38,8 @@ final class DebtSimulationTest extends TestCase
         foreach ($plans as $plan) {
             self::assertArrayHasKey('schedule', $plan);
             self::assertIsArray($plan['schedule']);
+            self::assertArrayHasKey('recommendations', $plan);
+            self::assertIsArray($plan['recommendations']);
             self::assertArrayHasKey('cost_of_deviation', $plan);
             self::assertArrayHasKey('currency', $plan['cost_of_deviation']);
             self::assertArrayHasKey('time_months', $plan['cost_of_deviation']);
@@ -85,6 +87,8 @@ final class DebtSimulationTest extends TestCase
         foreach ($plans as $plan) {
             self::assertArrayHasKey('schedule', $plan);
             self::assertIsArray($plan['schedule']);
+            self::assertArrayHasKey('recommendations', $plan);
+            self::assertIsArray($plan['recommendations']);
             self::assertArrayHasKey('cost_of_deviation', $plan);
             self::assertArrayHasKey('currency', $plan['cost_of_deviation']);
             self::assertArrayHasKey('time_months', $plan['cost_of_deviation']);


### PR DESCRIPTION
## Summary
- surface refinance suggestions in debt payoff schedules
- return recommendations via DebtController API
- document recommendations field in debt simulation endpoint

## Testing
- `php -l app/Modules/AI/Simulations/DebtSimulationService.php`
- `php -l app/Api/V1/Controllers/Simulations/DebtController.php`
- `php -l tests/unit/DebtSimulationTest.php`
- `composer unit-test`

------
https://chatgpt.com/codex/tasks/task_e_68af1474049483269e226bda6029209f