### PR TITLE
Add strategy and base-rate tests with CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,21 @@
+name: Python tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pandas numpy scikit-learn pytest flake8
+      - name: Lint
+        run: flake8 tests/fe --extend-ignore=E501
+      - name: Run tests
+        run: pytest tests/fe

--- a/tests/fe/base_rates/test_estimator.py
+++ b/tests/fe/base_rates/test_estimator.py
@@ -1,5 +1,10 @@
 import sys
+from datetime import datetime, timedelta
 from pathlib import Path
+
+import math
+import pandas as pd
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
@@ -7,8 +12,39 @@ from fe.base_rates import evaluate_brier_score  # noqa: E402
 import fe.base_rates.estimator as estimator  # noqa: E402
 
 
-def test_historical_brier_score_improves_over_baseline():
+@pytest.fixture
+def mock_historical(monkeypatch):
+    data = pd.DataFrame(
+        {
+            "category": ["politics"] * 10 + ["sports"] * 10,
+            "horizon_days": list(range(1, 11)) * 2,
+            "outcome": [1] * 4 + [0] * 6 + [0] * 4 + [1] * 6,
+        }
+    )
+
+    def fake_load_data():
+        estimator._DATA = data
+        estimator._MODELS = {}
+        for cat, df_cat in data.groupby("category"):
+            model = estimator.IsotonicRegression(out_of_bounds="clip")
+            model.fit(df_cat["horizon_days"], df_cat["outcome"])
+            estimator._MODELS[cat] = (model, df_cat)
+
+    monkeypatch.setattr(estimator, "_load_data", fake_load_data)
     estimator._DATA = None
     estimator._MODELS = {}
+    return data
+
+
+def test_historical_brier_score_improves_over_baseline(mock_historical):
     _, improvement = evaluate_brier_score(random_state=1)
     assert improvement > 0
+
+
+def test_estimate_prior_returns_no_nulls(mock_historical):
+    prob, ci = estimator.estimate_prior(
+        "politics", datetime.utcnow() + timedelta(days=10)
+    )
+    assert 0 <= prob <= 1 and not math.isnan(prob)
+    assert len(ci) == 2 and not any(math.isnan(v) for v in ci)
+    assert all(0 <= v <= 1 for v in ci)

--- a/tests/fe/strategies/test_backtest.py
+++ b/tests/fe/strategies/test_backtest.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from fe.strategies.backtest import run_backtest, walk_forward  # noqa: E402
+
+
+def threshold_strategy(data: pd.DataFrame, cutoff: float) -> pd.Series:
+    return (data["price"] > cutoff).astype(float)
+
+
+def make_prices(n: int = 30) -> pd.DataFrame:
+    return pd.DataFrame({"price": np.linspace(1.0, 1.3, n)})
+
+
+def test_run_backtest_no_nulls():
+    data = make_prices()
+    params = {"cutoff": [1.05, 1.15]}
+    results = run_backtest(
+        threshold_strategy, data, params, slippage=0.01, n_shuffles=5, seed=0
+    )
+    assert set("cutoff return sharpe max_drawdown p_value".split()).issubset(
+        results.columns
+    )
+    assert not results.isna().any().any()
+
+
+def test_walk_forward_no_nulls():
+    data = make_prices(40)
+    params = {"cutoff": [1.05, 1.15]}
+    results = walk_forward(
+        threshold_strategy, data, params, window=20, step=10, slippage=0.0
+    )
+    assert set("cutoff start end return cumulative".split()).issubset(
+        results.columns
+    )
+    assert not results.isna().any().any()


### PR DESCRIPTION
## Summary
- add vectorized backtest tests ensuring metrics and null-free output
- mock base-rate estimator data for deterministic tests
- run Python tests and lint in CI

## Testing
- `flake8 tests/fe/base_rates/test_estimator.py tests/fe/strategies/test_backtest.py --extend-ignore=E501`
- `pytest tests/fe`

------
https://chatgpt.com/codex/tasks/task_e_68af14758e8883269bad09e6c5c1a49c