### PR TITLE
Handle non-converging debt simulations gracefully

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -108,29 +108,38 @@ class DebtSimulationService
                     }
                 }
 
-                $plans = [];
+                $convergingPlans    = [];
+                $nonConvergingPlans = [];
                 foreach ($this->strategies as $strategy) {
-                    $plan    = $this->generateSchedule($debts, $budget, $strategy);
-                    $plans[] = array_merge(
+                    $plan     = $this->generateSchedule($debts, $budget, $strategy);
+                    $fullPlan = array_merge(
                         [
                             'strategy' => $strategy->getName(),
                             'meta'     => ['strategy_explanation' => $strategy->getExplanation()],
                         ],
                         $plan
                     );
+                    if (($fullPlan['status'] ?? 'ok') === 'non_converging') {
+                        $nonConvergingPlans[] = $fullPlan;
+                    } else {
+                        $convergingPlans[] = $fullPlan;
+                    }
                 }
 
-                usort($plans, static function (array $a, array $b): int {
+                usort($convergingPlans, static function (array $a, array $b): int {
                     return [$a['total_interest'], $a['months']] <=> [$b['total_interest'], $b['months']];
                 });
 
-                $plans = array_slice($plans, 0, $maxOptions);
+                $convergingPlans = array_slice($convergingPlans, 0, $maxOptions);
 
-                $bestInterest = $plans[0]['total_interest'] ?? 0.0;
-                $bestMonths   = $plans[0]['months'] ?? 0;
+                $plans = array_merge($convergingPlans, $nonConvergingPlans);
 
-                // Ensure the baseline interest is at least as high as any plan.
-                $maxInterest = max(array_column($plans, 'total_interest'));
+                $bestInterest = $convergingPlans[0]['total_interest'] ?? ($plans[0]['total_interest'] ?? 0.0);
+                $bestMonths   = $convergingPlans[0]['months'] ?? ($plans[0]['months'] ?? 0);
+
+                // Ensure the baseline interest is at least as high as any converging plan.
+                $interestPool = [] !== $convergingPlans ? $convergingPlans : $plans;
+                $maxInterest  = [] === $interestPool ? 0.0 : max(array_column($interestPool, 'total_interest'));
                 if (null === $baselineInterest || $baselineInterest < $maxInterest) {
                     $baselineInterest = $maxInterest;
                 }
@@ -140,7 +149,7 @@ class DebtSimulationService
                     $status = $plan['status'] ?? 'ok';
 
                     $plan['rank']                  = $i + 1;
-                    $plan['is_optimal']            = 0 === $i;
+                    $plan['is_optimal']            = 0 === $i && 'ok' === $status;
                     $plan['total_interest']        = (float) $plan['total_interest'];
                     $plan['interest_saved']        = $baselineInterest - $plan['total_interest'];
                     $plan['time_to_payoff_months'] = $plan['months'];
@@ -157,6 +166,10 @@ class DebtSimulationService
                             $plan['cost_of_deviation']['time_months']
                         );
 
+                    $rankingReason = $plan['is_optimal']
+                        ? 'maximizes interest savings'
+                        : ('non_converging' === $status ? 'plan does not converge' : 'less interest saved or longer duration');
+
                     $plan['meta'] = array_merge(
                         $plan['meta'],
                         [
@@ -166,9 +179,7 @@ class DebtSimulationService
                                 'months'         => $plan['months'],
                             ],
                             'tradeoff_drivers'  => $plan['cost_of_deviation'],
-                            'ranking_reason'    => $plan['is_optimal']
-                                ? 'maximizes interest savings'
-                                : 'less interest saved or longer duration',
+                            'ranking_reason'    => $rankingReason,
                             'tradeoffs'         => $tradeoffString,
                         ]
                     );

--- a/tests/api/v1/Simulations/DebtSimulationTest.php
+++ b/tests/api/v1/Simulations/DebtSimulationTest.php
@@ -204,4 +204,89 @@ final class DebtSimulationTest extends TestCase
         self::assertSame(1, $actions[0]['rank']);
         self::assertArrayHasKey('strategy_explanation', $actions[0]['meta']);
     }
+
+    public function testNonConvergingPlanIsNotOptimal(): void
+    {
+        Cache::setDefaultDriver('file');
+        putenv('CACHE_DRIVER=file');
+        Cache::flush();
+        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
+        config(['auth.defaults.guard' => 'web']);
+
+        $this->ensureUuidColumns();
+
+        $user = User::create(['email' => 'user@example.com', 'password' => 'secret']);
+        CreatesGroupMemberships::createGroupMembership($user);
+        $user->refresh();
+        if ($user->uuid === null) {
+            $user->uuid = (string) Str::uuid();
+            $user->save();
+            $user->refresh();
+        }
+        $this->be($user);
+
+        $type = AccountType::where('type', AccountTypeEnum::DEBT->value)->first();
+        $a1   = Account::create([
+            'user_id'         => $user->id,
+            'user_group_id'   => $user->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'High APR',
+            'active'          => true,
+        ]);
+        $a1->refresh();
+        if ($a1->uuid === null) {
+            $a1->uuid = (string) Str::uuid();
+            $a1->save();
+            $a1->refresh();
+        }
+        $a2 = Account::create([
+            'user_id'         => $user->id,
+            'user_group_id'   => $user->user_group_id,
+            'account_type_id' => $type->id,
+            'name'            => 'Low APR',
+            'active'          => true,
+        ]);
+        $a2->refresh();
+        if ($a2->uuid === null) {
+            $a2->uuid = (string) Str::uuid();
+            $a2->save();
+            $a2->refresh();
+        }
+
+        $accounts = [
+            [
+                'account_id'      => (string) $a1->uuid,
+                'balance'         => 1000.0,
+                'apr'             => 120.0,
+                'minimum_payment' => 0.0,
+            ],
+            [
+                'account_id'      => (string) $a2->uuid,
+                'balance'         => 100.0,
+                'apr'             => 0.0,
+                'minimum_payment' => 0.0,
+            ],
+        ];
+
+        $payload = [
+            'user_id'        => (string) $user->uuid,
+            'group_id'       => null,
+            'accounts'       => $accounts,
+            'monthly_budget' => 150.0,
+            'max_options'    => 3,
+        ];
+
+        $response = $this->postJson('/api/v1/simulations/debt', $payload)->assertOk();
+
+        $actions = $response->json('proposed_actions');
+        self::assertSame('ok', $actions[0]['plan']['status']);
+        self::assertTrue($actions[0]['is_optimal']);
+
+        foreach ($actions as $action) {
+            if ($action['plan']['status'] === 'non_converging') {
+                self::assertFalse($action['is_optimal']);
+                self::assertGreaterThan(1, $action['rank']);
+            }
+        }
+    }
 }

--- a/tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php
@@ -27,6 +27,7 @@ final class DebtSimulationNonConvergingTest extends TestCase
         $plans = $service->simulate('user', 'group', $accounts, $budget, 1);
 
         self::assertSame('non_converging', $plans[0]['status']);
+        self::assertFalse($plans[0]['is_optimal']);
         self::assertLessThanOrEqual(DebtSimulationService::MAX_MONTHS, $plans[0]['months']);
     }
 }


### PR DESCRIPTION
## Summary
- Skip ranking for non-converging debt payoff plans and always rank them after converging options
- Add API test to ensure non-converging plans are never marked optimal
- Verify unit test reflects non-converging plans as non-optimal

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpstan analyze --memory-limit=1G app/Modules/AI/Simulations/DebtSimulationService.php tests/api/v1/Simulations/DebtSimulationTest.php tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpunit tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php tests/api/v1/Simulations/DebtSimulationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68af147520108326b025f56d9f923545