### PR TITLE
Add backtest slippage and walk-forward tests

### DIFF
--- a/tests/fe/strategies/test_backtest.py
+++ b/tests/fe/strategies/test_backtest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
@@ -15,6 +16,11 @@ def threshold_strategy(data: pd.DataFrame, cutoff: float) -> pd.Series:
 
 def make_prices(n: int = 30) -> pd.DataFrame:
     return pd.DataFrame({"price": np.linspace(1.0, 1.3, n)})
+
+
+def flip_strategy(data: pd.DataFrame) -> pd.Series:
+    """Predefined position sequence to expose slippage effects."""
+    return pd.Series([0.0, 1.0, 1.0, 0.0], index=data.index)
 
 
 def test_run_backtest_no_nulls():
@@ -39,3 +45,32 @@ def test_walk_forward_no_nulls():
         results.columns
     )
     assert not results.isna().any().any()
+
+
+def test_run_backtest_slippage_metrics():
+    data = pd.DataFrame({"price": [1.0, 1.1, 1.2, 1.1]})
+    with_slip = run_backtest(flip_strategy, data, {}, slippage=0.01)
+    no_slip = run_backtest(flip_strategy, data, {}, slippage=0.0)
+
+    assert with_slip.loc[0, "return"] == pytest.approx(-0.0208, rel=1e-6)
+    assert with_slip.loc[0, "sharpe"] == pytest.approx(-0.654296, rel=1e-6)
+    assert with_slip.loc[0, "max_drawdown"] == pytest.approx(-0.0933333, rel=1e-6)
+    assert with_slip.loc[0, "return"] < no_slip.loc[0, "return"]
+
+
+def test_walk_forward_evaluation():
+    prices = pd.Series([1.0, 1.1, 1.2, 1.3, 1.4, 1.3, 1.2, 1.1])
+    data = pd.DataFrame({"price": prices})
+    params = {"cutoff": [1.05, 1.15]}
+    result = walk_forward(
+        threshold_strategy, data, params, window=4, step=2, slippage=0.0
+    )
+    assert result["cutoff"].tolist() == [1.05, 1.05]
+    assert result["start"].tolist() == [4, 6]
+    assert result["end"].tolist() == [5, 7]
+    assert result["return"].tolist() == pytest.approx(
+        [-0.0714285714, -0.0833333333], abs=1e-6
+    )
+    assert result["cumulative"].tolist() == pytest.approx(
+        [-0.0714285714, -0.1488095238], abs=1e-6
+    )


### PR DESCRIPTION
## Summary
- add unit test covering slippage impact on return, Sharpe, and drawdown
- add walk-forward evaluation test with expected returns and cumulative performance

## Testing
- `ruff check tests/fe/strategies/test_backtest.py fe/strategies/backtest.py`
- `pytest tests/fe/strategies/test_backtest.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1d1380c08326a3f169f6c3daffdf