### PR TITLE
Add comprehensive tests for features and gating logic

### DIFF
--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
 from fe.features.drift import rolling_drift  # noqa: E402
 
 
@@ -26,3 +27,9 @@ def test_drift_flat():
     expected = pd.Series([float("nan"), float("nan"), 0.0, 0.0])
     result = rolling_drift(prices, window=2)
     pd.testing.assert_series_equal(result, expected)
+
+
+def test_drift_invalid_window():
+    prices = pd.Series([1, 2, 3])
+    with pytest.raises(ValueError):
+        rolling_drift(prices, window=0)

--- a/tests/test_estimator_brier.py
+++ b/tests/test_estimator_brier.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pandas as pd  # noqa: E402
+from fe.base_rates import evaluate_brier_score  # noqa: E402
+import fe.base_rates.estimator as estimator  # noqa: E402
+
+
+def test_brier_score_improvement_positive():
+    df = pd.DataFrame({
+        "category": ["sample"] * 10,
+        "horizon_days": list(range(10, 110, 10)),
+        "outcome": [0] * 5 + [1] * 5,
+    })
+    estimator._DATA = df
+    estimator._MODELS = {}
+    score, improvement = evaluate_brier_score()
+    assert improvement > 0
+    assert 0 <= score <= 1

--- a/tests/test_liquidity.py
+++ b/tests/test_liquidity.py
@@ -1,0 +1,45 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pandas as pd  # noqa: E402
+from fe.features.liquidity import compute_liquidity  # noqa: E402
+from pytest import approx  # noqa: E402
+
+
+def test_compute_liquidity_basic():
+    df = pd.DataFrame(
+        {
+            "market_id": [1, 1, 2, 2],
+            "timestamp": [
+                "2023-01-01T00:00:00Z",
+                "2023-01-01T00:30:00Z",
+                "2023-01-01T00:15:00Z",
+                "2022-12-31T22:00:00Z",
+            ],
+            "bids": [
+                [[0.9, 10], [0.8, 5]],
+                None,
+                [[0.9, 8]],
+                [[0.8, 4]],
+            ],
+            "asks": [
+                [[1.1, 7]],
+                [[1.2, 4]],
+                None,
+                [[1.0, 1]],
+            ],
+        }
+    )
+
+    result = compute_liquidity(df, hours=1)
+    assert set(result.index) == {1, 2}
+    assert result.loc[1] == approx(6.5)
+    assert result.loc[2] == approx(4.0)
+
+
+def test_compute_liquidity_empty():
+    df = pd.DataFrame(columns=["market_id", "timestamp", "bids", "asks"])
+    result = compute_liquidity(df)
+    assert result.empty

--- a/tests/test_rule_objectivity.py
+++ b/tests/test_rule_objectivity.py
@@ -1,0 +1,44 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fe.features.rule_objectivity import (  # noqa: E402
+    batch_score,
+    score_rule_objectivity,
+)
+
+
+def test_score_unknown():
+    assert score_rule_objectivity(None) == "unknown"
+    assert score_rule_objectivity("   ") == "unknown"
+
+
+def test_score_clear_keyword_and_pattern():
+    rule = "Outcome will be determined by official sources within 3 days"
+    assert score_rule_objectivity(rule) == "clear"
+
+
+def test_score_ambiguous_keyword():
+    rule = "Result may be at admin's sole discretion"
+    assert score_rule_objectivity(rule) == "ambiguous"
+
+
+def test_score_ambiguous_pattern():
+    rule = "Approx. value to be resolved"
+    assert score_rule_objectivity(rule) == "ambiguous"
+
+
+def test_score_numeric_sets_clear():
+    rule = "The value must reach 10"
+    assert score_rule_objectivity(rule) == "clear"
+
+
+def test_score_default_clear():
+    rule = "ordinary text without keywords"
+    assert score_rule_objectivity(rule) == "clear"
+
+
+def test_batch_score():
+    rules = [None, "Outcome may be unknown", "Outcome will be official"]
+    assert batch_score(rules) == ["unknown", "ambiguous", "clear"]

--- a/tests/test_signoff_gate.py
+++ b/tests/test_signoff_gate.py
@@ -1,0 +1,34 @@
+import pathlib
+import sys
+import json
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fe.signoff.gate import (  # noqa: E402
+    ALPHA,
+    MAX_MDD,
+    MIN_SAMPLE,
+    approve,
+)
+
+
+def test_approve_passes_default_thresholds():
+    report = {"sample_size": MIN_SAMPLE, "max_drawdown": MAX_MDD, "p_value": ALPHA - 0.01}
+    assert approve(report)
+
+
+def test_approve_rejects_on_threshold():
+    report = {"sample_size": MIN_SAMPLE - 1, "max_drawdown": MAX_MDD, "p_value": ALPHA - 0.01}
+    assert not approve(report)
+
+
+def test_approve_with_overrides():
+    report = {"sample_size": 10, "max_drawdown": 0.3, "p_value": 0.04}
+    assert approve(report, min_sample=5, max_mdd=0.5, alpha=0.05)
+
+
+def test_approve_with_config_file(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"MIN_SAMPLE": 5, "MAX_MDD": 0.5, "ALPHA": 0.1}))
+    report = {"sample_size": 6, "max_drawdown": 0.4, "p_value": 0.05}
+    assert approve(report, config_path=cfg)

--- a/tests/test_skew.py
+++ b/tests/test_skew.py
@@ -14,3 +14,7 @@ def test_symmetric_market_has_zero_skew() -> None:
 def test_skew_is_normalized() -> None:
     assert price_skew(1.0, 0.0) == approx(1)
     assert price_skew(0.0, 1.0) == approx(-1)
+
+
+def test_skew_zero_prices() -> None:
+    assert price_skew(0.0, 0.0) == approx(0)

--- a/tests/test_time_to_deadline.py
+++ b/tests/test_time_to_deadline.py
@@ -1,0 +1,44 @@
+import pathlib
+import sys
+from datetime import datetime, timezone, timedelta
+import math
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fe.features.time_to_deadline import time_to_deadline  # noqa: E402
+from pytest import approx  # noqa: E402
+
+
+def test_time_to_deadline_none():
+    assert math.isnan(time_to_deadline(None))
+
+
+def test_time_to_deadline_mixed_naive_and_aware():
+    deadline = datetime(2024, 1, 2)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert time_to_deadline(deadline, now) == approx(1.0)
+
+
+def test_time_to_deadline_both_naive():
+    deadline = datetime(2024, 1, 2)
+    now = datetime(2024, 1, 1)
+    assert time_to_deadline(deadline, now) == approx(1.0)
+
+
+def test_time_to_deadline_both_aware():
+    deadline = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    now = datetime(2023, 12, 31, 23, tzinfo=timezone(timedelta(hours=1)))
+    expected = 2 / 24  # two hours difference in days
+    assert time_to_deadline(deadline, now) == approx(expected)
+
+
+def test_time_to_deadline_default_now():
+    deadline = datetime.now(timezone.utc) + timedelta(days=1)
+    result = time_to_deadline(deadline)
+    assert result == approx(1.0, rel=1e-3)
+
+
+def test_time_to_deadline_deadline_aware_now_naive():
+    deadline = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    now = datetime(2024, 1, 1)
+    assert time_to_deadline(deadline, now) == approx(1.0)


### PR DESCRIPTION
## Summary
- Expand feature tests for drift, skew, liquidity, rule objectivity, and time-to-deadline utilities
- Validate Brier score improvement in base rate estimator
- Ensure signoff gate thresholds and configuration overrides behave as expected

## Testing
- `flake8 tests/test_drift.py tests/test_skew.py tests/test_liquidity.py tests/test_rule_objectivity.py tests/test_time_to_deadline.py tests/test_signoff_gate.py tests/test_estimator_brier.py --extend-ignore=E501`
- `pytest tests/test_drift.py tests/test_skew.py tests/test_liquidity.py tests/test_rule_objectivity.py tests/test_time_to_deadline.py tests/test_signoff_gate.py tests/test_estimator_brier.py tests/fe/base_rates/test_estimator.py tests/unit/base_rates/test_estimator_taxonomy.py --cov=fe.features --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68af1d1295d483268b9a483d5e079d01