### PR TITLE
Implement ML strategy inference with configurable model path

### DIFF
--- a/app/Modules/AI/Simulations/Strategies/MlStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/MlStrategy.php
@@ -52,7 +52,31 @@ class MlStrategy implements StrategyInterface
      */
     protected function infer(array $features): ?int
     {
-        // Integrate with ML model here.
+        $modelPath = config('ai.ml_model_path');
+
+        if (!is_string($modelPath) || !is_file($modelPath)) {
+            return null;
+        }
+
+        if (!class_exists('\\ONNXRuntime\\InferenceSession')) {
+            return null;
+        }
+
+        try {
+            $session     = new \ONNXRuntime\InferenceSession($modelPath);
+            $result      = $session->run(['input' => $features]);
+            $predictions = $result[0] ?? $result['output'] ?? null;
+
+            if (is_array($predictions) && [] !== $predictions) {
+                $index = array_search(max($predictions), $predictions, true);
+                if (false !== $index) {
+                    return (int) $index;
+                }
+            }
+        } catch (\Throwable $e) {
+            report($e);
+        }
+
         return null;
     }
 

--- a/config/ai.php
+++ b/config/ai.php
@@ -8,4 +8,5 @@ return [
         \FireflyIII\Modules\AI\Simulations\Strategies\BalancedStrategy::class,
         \FireflyIII\Modules\AI\Simulations\Strategies\MlStrategy::class,
     ],
+    'ml_model_path' => env('ML_MODEL_PATH', storage_path('app/ai/ml_model.onnx')),
 ];

--- a/tests/unit/DebtSimulationTest.php
+++ b/tests/unit/DebtSimulationTest.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 namespace Tests\unit;
 
 use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use FireflyIII\Modules\AI\Simulations\Strategies\AvalancheStrategy;
+use FireflyIII\Modules\AI\Simulations\Strategies\BalancedStrategy;
+use FireflyIII\Modules\AI\Simulations\Strategies\SnowballStrategy;
 use Tests\integration\TestCase;
 
 /**
@@ -24,7 +27,11 @@ final class DebtSimulationTest extends TestCase
     public function testGeneratesIdenticalPlansForSingleAccount(): void
     {
         $user = $this->createAuthenticatedUser();
-        $service = new DebtSimulationService();
+        $service = new DebtSimulationService([
+            AvalancheStrategy::class,
+            SnowballStrategy::class,
+            BalancedStrategy::class,
+        ]);
 
         $accounts = [
             ['account_id' => 1, 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
@@ -75,7 +82,11 @@ final class DebtSimulationTest extends TestCase
     public function testRanksAvalancheAheadOfSnowballWithMetrics(): void
     {
         $user = $this->createAuthenticatedUser();
-        $service = new DebtSimulationService();
+        $service = new DebtSimulationService([
+            AvalancheStrategy::class,
+            SnowballStrategy::class,
+            BalancedStrategy::class,
+        ]);
 
         $accounts = [
             ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
@@ -130,7 +141,11 @@ final class DebtSimulationTest extends TestCase
     public function testMetaContainsRankingReasonAndTradeoffs(): void
     {
         $user    = $this->createAuthenticatedUser();
-        $service = new DebtSimulationService();
+        $service = new DebtSimulationService([
+            AvalancheStrategy::class,
+            SnowballStrategy::class,
+            BalancedStrategy::class,
+        ]);
 
         $accounts = [
             ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],

--- a/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
@@ -21,7 +21,11 @@ final class DebtSimulationServiceRankingTest extends TestCase
     {
         Cache::flush();
 
-        $service = new DebtSimulationService();
+        $service = new DebtSimulationService([
+            AvalancheStrategy::class,
+            SnowballStrategy::class,
+            BalancedStrategy::class,
+        ]);
         $user    = $this->createAuthenticatedUser();
 
         $accounts = [
@@ -37,7 +41,8 @@ final class DebtSimulationServiceRankingTest extends TestCase
 
         $bestInterest     = $plans[0]['total_interest'];
         $bestMonths       = $plans[0]['months'];
-        $baselineInterest = max(array_column($plans, 'total_interest'));
+        $totals           = array_column($plans, 'total_interest');
+        $baselineInterest = max([] !== $totals ? $totals : [0]);
 
         foreach ($plans as $plan) {
             $expectedCurrency      = $plan['total_interest'] - $bestInterest;

--- a/tests/unit/Modules/AI/MlStrategyTest.php
+++ b/tests/unit/Modules/AI/MlStrategyTest.php
@@ -2,61 +2,137 @@
 
 declare(strict_types=1);
 
-namespace Tests\unit\Modules\AI;
-
-use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
-use Illuminate\Support\Facades\Cache;
-use Tests\integration\TestCase;
-
-/**
- * @group unit-test
- * @group ai
- */
-final class MlStrategyTest extends TestCase
-{
-    public function testStrategyIsInvokedAndRankedWithAnnotations(): void
+namespace ONNXRuntime {
+    class InferenceSession
     {
-        Cache::flush();
+        public static bool $shouldThrow = false;
+        public static array $output = [[0.0]];
+        private string $path;
 
-        $service = new DebtSimulationService();
-        $user    = $this->createAuthenticatedUser();
+        public function __construct(string $path)
+        {
+            $this->path = $path;
+        }
 
-        $accounts = [
-            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
-            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
-        ];
+        public function getPath(): string
+        {
+            return $this->path;
+        }
 
-        $plans = $service->simulate((string) $user->id, '1', $accounts, 300.0, 4);
+        public function run(array $inputs): array
+        {
+            if (self::$shouldThrow) {
+                throw new \RuntimeException('inference error');
+            }
 
-        self::assertCount(4, $plans);
-
-        $strategies = array_column($plans, 'strategy');
-        self::assertContains('ml', $strategies);
-        $mlIndex = array_search('ml', $strategies, true);
-        self::assertNotFalse($mlIndex);
-        $mlPlan = $plans[$mlIndex];
-
-        // ensure ml strategy ranked last and is marked non-converging
-        self::assertSame($mlIndex + 1, $mlPlan['rank']);
-        self::assertSame('non_converging', $mlPlan['status']);
-
-        // cost-of-deviation relative to best plan
-        $bestPlan         = $plans[0];
-        $expectedCurrency = $mlPlan['total_interest'] - $bestPlan['total_interest'];
-        $expectedMonths   = $mlPlan['months'] - $bestPlan['months'];
-        self::assertEqualsWithDelta($expectedCurrency, $mlPlan['cost_of_deviation']['currency'], 0.0001);
-        self::assertSame($expectedMonths, $mlPlan['cost_of_deviation']['time_months']);
-
-        // meta field validation
-        self::assertSame(DebtSimulationService::RANKING_HEURISTIC, $mlPlan['meta']['ranking_heuristic']);
-        self::assertIsString($mlPlan['meta']['ranking_reason']);
-        self::assertIsString($mlPlan['meta']['tradeoffs']);
-        self::assertIsArray($mlPlan['meta']['heuristic_scores']);
-        self::assertArrayHasKey('total_interest', $mlPlan['meta']['heuristic_scores']);
-        self::assertArrayHasKey('months', $mlPlan['meta']['heuristic_scores']);
-        self::assertIsArray($mlPlan['meta']['tradeoff_drivers']);
-        self::assertArrayHasKey('currency', $mlPlan['meta']['tradeoff_drivers']);
-        self::assertArrayHasKey('time_months', $mlPlan['meta']['tradeoff_drivers']);
-        self::assertIsString($mlPlan['meta']['strategy_explanation']);
+            return self::$output;
+        }
     }
 }
+
+namespace Tests\unit\Modules\AI {
+
+    use FireflyIII\Modules\AI\Simulations\Strategies\MlStrategy;
+    use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+    use Illuminate\Support\Facades\Cache;
+    use Tests\integration\TestCase;
+    use function Safe\tempnam;
+
+    /**
+     * @group unit-test
+     * @group ai
+     */
+    final class MlStrategyTest extends TestCase
+    {
+        public function testSuccessfulInference(): void
+        {
+            $original = config('ai.ml_model_path');
+            $modelPath = tempnam(sys_get_temp_dir(), 'model');
+            config(['ai.ml_model_path' => $modelPath]);
+
+            \ONNXRuntime\InferenceSession::$shouldThrow = false;
+            \ONNXRuntime\InferenceSession::$output = [[0.1, 0.7, 0.2]];
+
+            $strategy = new MlStrategy();
+            $debts    = [
+                ['balance' => 100.0, 'rate' => 1.0, 'min_payment' => 10.0],
+                ['balance' => 200.0, 'rate' => 2.0, 'min_payment' => 20.0],
+                ['balance' => 50.0, 'rate' => 3.0, 'min_payment' => 5.0],
+            ];
+
+            $result = $strategy->selectTargetDebt($debts);
+
+            self::assertSame(1, $result);
+
+            config(['ai.ml_model_path' => $original]);
+        }
+
+        public function testInferenceFallbackOnError(): void
+        {
+            $original = config('ai.ml_model_path');
+            $modelPath = tempnam(sys_get_temp_dir(), 'model');
+            config(['ai.ml_model_path' => $modelPath]);
+
+            \ONNXRuntime\InferenceSession::$shouldThrow = true;
+
+            $strategy = new MlStrategy();
+            $debts    = [
+                ['balance' => 100.0, 'rate' => 1.0, 'min_payment' => 10.0],
+            ];
+
+            $result = $strategy->selectTargetDebt($debts);
+
+            self::assertNull($result);
+
+            \ONNXRuntime\InferenceSession::$shouldThrow = false;
+            config(['ai.ml_model_path' => $original]);
+        }
+
+        public function testStrategyIsInvokedAndRankedWithAnnotations(): void
+        {
+            Cache::flush();
+
+            $service = new DebtSimulationService();
+            $user    = $this->createAuthenticatedUser();
+
+            $accounts = [
+                ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
+                ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
+            ];
+
+            $plans = $service->simulate((string) $user->id, '1', $accounts, 300.0, 4);
+
+            self::assertCount(4, $plans);
+
+            $strategies = array_column($plans, 'strategy');
+            self::assertContains('ml', $strategies);
+            $mlIndex = array_search('ml', $strategies, true);
+            self::assertNotFalse($mlIndex);
+            $mlPlan = $plans[$mlIndex];
+
+            // ensure ml strategy ranked last and is marked non-converging
+            self::assertSame($mlIndex + 1, $mlPlan['rank']);
+            self::assertSame('non_converging', $mlPlan['status']);
+
+            // cost-of-deviation relative to best plan
+            $bestPlan         = $plans[0];
+            $expectedCurrency = $mlPlan['total_interest'] - $bestPlan['total_interest'];
+            $expectedMonths   = $mlPlan['months'] - $bestPlan['months'];
+            self::assertEqualsWithDelta($expectedCurrency, $mlPlan['cost_of_deviation']['currency'], 0.0001);
+            self::assertSame($expectedMonths, $mlPlan['cost_of_deviation']['time_months']);
+
+            // meta field validation
+            self::assertSame(DebtSimulationService::RANKING_HEURISTIC, $mlPlan['meta']['ranking_heuristic']);
+            self::assertIsString($mlPlan['meta']['ranking_reason']);
+            self::assertIsString($mlPlan['meta']['tradeoffs']);
+            self::assertIsArray($mlPlan['meta']['heuristic_scores']);
+            self::assertArrayHasKey('total_interest', $mlPlan['meta']['heuristic_scores']);
+            self::assertArrayHasKey('months', $mlPlan['meta']['heuristic_scores']);
+            self::assertIsArray($mlPlan['meta']['tradeoff_drivers']);
+            self::assertArrayHasKey('currency', $mlPlan['meta']['tradeoff_drivers']);
+            self::assertArrayHasKey('time_months', $mlPlan['meta']['tradeoff_drivers']);
+            self::assertIsString($mlPlan['meta']['strategy_explanation']);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- connect `MlStrategy` to ONNX runtime inference using a model path from config
- make model path configurable via `ai.ml_model_path`
- add tests for successful model inference and graceful fallback
- update existing debt simulation tests to exclude ML strategy by default

## Testing
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa vendor/bin/phpstan analyse -c .ci/phpstan.neon --memory-limit=512M app/Modules/AI/Simulations/Strategies/MlStrategy.php tests/unit/Modules/AI/MlStrategyTest.php tests/unit/DebtSimulationTest.php tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php`
- `composer run unit-test`

------
https://chatgpt.com/codex/tasks/task_e_68b6e92e1a2c8326814191715fe49fe7