### PR TITLE
feat: add walk-forward splitting utilities

### DIFF
--- a/fe/strategies/__init__.py
+++ b/fe/strategies/__init__.py
@@ -1,6 +1,12 @@
 """Strategy utilities."""
 
 from .backtest import run_backtest, walk_forward
+from .walk_forward import aggregate_performance, walk_forward_splits
 
-__all__ = ["run_backtest", "walk_forward"]
+__all__ = [
+    "run_backtest",
+    "walk_forward",
+    "walk_forward_splits",
+    "aggregate_performance",
+]
 

--- a/fe/strategies/walk_forward.py
+++ b/fe/strategies/walk_forward.py
@@ -1,0 +1,64 @@
+"""Walk-forward utilities."""
+
+from __future__ import annotations
+
+from typing import Iterator, Sequence, Tuple
+
+import pandas as pd
+
+
+def walk_forward_splits(
+    data: pd.DataFrame,
+    window: int,
+    step: int,
+) -> Iterator[Tuple[pd.DataFrame, pd.DataFrame]]:
+    """Yield rolling train/test windows.
+
+    Parameters
+    ----------
+    data:
+        Input dataset.
+    window:
+        Size of the training window.
+    step:
+        Size of each test window and the shift between windows.
+
+    Yields
+    ------
+    tuple[pd.DataFrame, pd.DataFrame]
+        The training and testing slices for each step.
+    """
+    if window <= 0 or step <= 0:
+        raise ValueError("window and step must be positive")
+
+    for start in range(window, len(data), step):
+        train = data.iloc[start - window:start]
+        test = data.iloc[start:start + step]
+        if test.empty:
+            break
+        yield train, test
+
+
+def aggregate_performance(returns: Sequence[float]) -> pd.DataFrame:
+    """Aggregate per-window returns into cumulative performance.
+
+    Parameters
+    ----------
+    returns:
+        Sequence of per-window returns.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with ``return`` and ``cumulative`` columns where the latter
+        contains compounded returns.
+    """
+    cumulative = 1.0
+    rows = []
+    for r in returns:
+        cumulative *= 1.0 + r
+        rows.append({"return": float(r), "cumulative": cumulative - 1.0})
+    return pd.DataFrame(rows)
+
+
+__all__ = ["walk_forward_splits", "aggregate_performance"]

--- a/tests/fe/strategies/test_walk_forward.py
+++ b/tests/fe/strategies/test_walk_forward.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from fe.strategies.walk_forward import (  # noqa: E402
+    aggregate_performance,
+    walk_forward_splits,
+)
+
+
+def test_walk_forward_splits_alignment():
+    data = pd.DataFrame({"price": np.arange(10)}, index=np.arange(10))
+    splits = list(walk_forward_splits(data, window=4, step=2))
+    assert len(splits) == 3
+    for i, (train, test) in enumerate(splits):
+        expected_train = np.arange(i * 2, i * 2 + 4)
+        expected_test = np.arange(4 + i * 2, 4 + i * 2 + 2)
+        assert (train.index.values == expected_train).all()
+        assert (test.index.values == expected_test).all()
+
+
+def test_aggregate_performance():
+    returns = [0.1, -0.05, 0.02]
+    perf = aggregate_performance(returns)
+    assert perf["return"].tolist() == returns
+    cumulative = 1.0
+    expected = []
+    for r in returns:
+        cumulative *= 1.0 + r
+        expected.append(cumulative - 1.0)
+    assert perf["cumulative"].tolist() == pytest.approx(expected, rel=1e-6)


### PR DESCRIPTION
## Summary
- add walk_forward_splits for rolling train/test windows
- provide aggregate_performance to compound window returns
- cover window alignment and aggregation in tests

## Testing
- `flake8 fe/strategies/walk_forward.py tests/fe/strategies/test_walk_forward.py`
- `pytest tests/fe/strategies/test_walk_forward.py tests/fe/strategies/test_backtest.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f2baf16083268526834d7cc1fc1d