### PR TITLE
Add corporate taxonomy category with historical data and tests

### DIFF
--- a/fe/base_rates/historical.csv
+++ b/fe/base_rates/historical.csv
@@ -7,3 +7,11 @@ sports,30,1
 sports,60,1
 sports,90,0
 sports,120,0
+geopolitics,30,1
+geopolitics,60,0
+geopolitics,90,1
+geopolitics,120,0
+corporate,30,0
+corporate,60,1
+corporate,90,0
+corporate,120,1

--- a/fe/base_rates/taxonomy.yaml
+++ b/fe/base_rates/taxonomy.yaml
@@ -50,3 +50,9 @@ market_microstructure:
     weekly:
       # Higher-level view to smooth short-term noise.
       description: "Data aggregated per week."
+corporate:
+  # Company-level events and governance changes.
+  horizons:
+    ceo_change:
+      # Evaluates market reactions to CEO transitions.
+      description: "Group events by the announcement or effective date of CEO changes."

--- a/tests/fe/base_rates/test_taxonomy.py
+++ b/tests/fe/base_rates/test_taxonomy.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+
+def test_taxonomy_includes_expected_categories():
+    base_dir = Path(__file__).resolve().parents[3] / "fe" / "base_rates"
+    taxonomy = yaml.safe_load((base_dir / "taxonomy.yaml").read_text())
+    assert "geopolitics" in taxonomy
+    assert "corporate" in taxonomy
+    assert "by_date" in taxonomy["geopolitics"]["horizons"]
+    assert "ceo_change" in taxonomy["corporate"]["horizons"]
+
+
+def test_new_categories_have_historical_data():
+    base_dir = Path(__file__).resolve().parents[3] / "fe" / "base_rates"
+    taxonomy = yaml.safe_load((base_dir / "taxonomy.yaml").read_text())
+    data = pd.read_csv(base_dir / "historical.csv")
+    for category in ["geopolitics", "corporate"]:
+        assert category in taxonomy
+        assert (data["category"] == category).any()


### PR DESCRIPTION
## Summary
- expand base rate taxonomy with a new corporate.ceo_change horizon and ensure geopolitics.by_date remains defined
- extend historical base rate data to cover corporate and geopolitics slices
- test YAML taxonomy parsing and data mapping for new categories

## Testing
- `python -m flake8 tests/fe/base_rates/test_taxonomy.py`
- `pytest tests/fe/base_rates/test_taxonomy.py -q`
- `pytest tests/fe/base_rates/test_estimator.py -q`
- `PYTHONPATH=. pytest tests/unit/base_rates/test_estimator_taxonomy.py -q`
- `pytest tests/python/test_base_rates.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b842ced504832684c9d93b17d66b3b