### PR TITLE
Add signoff gate tests for config overrides

### DIFF
--- a/tests/fe/signoff/config/lenient.json
+++ b/tests/fe/signoff/config/lenient.json
@@ -1,0 +1,5 @@
+{
+  "MIN_SAMPLE": 5,
+  "MAX_MDD": 0.5,
+  "ALPHA": 0.5
+}

--- a/tests/fe/signoff/config/strict.json
+++ b/tests/fe/signoff/config/strict.json
@@ -1,0 +1,5 @@
+{
+  "MIN_SAMPLE": 100,
+  "MAX_MDD": 0.1,
+  "ALPHA": 0.01
+}

--- a/tests/fe/signoff/test_gate.py
+++ b/tests/fe/signoff/test_gate.py
@@ -1,56 +1,38 @@
-import sys
-import json
 from pathlib import Path
+import sys
 
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
-from fe.signoff.gate import approve  # noqa: E402
+from fe.signoff.gate import ALPHA, MAX_MDD, MIN_SAMPLE, approve  # noqa: E402
+
+CONFIG_DIR = Path(__file__).with_name("config")
 
 
-def test_gate_passes_when_all_thresholds_met():
-    report = {"sample_size": 50, "max_drawdown": 0.1, "p_value": 0.01}
+def test_approve_defaults_pass():
+    report = {"sample_size": MIN_SAMPLE, "max_drawdown": MAX_MDD, "p_value": ALPHA - 0.001}
     assert approve(report)
 
 
 @pytest.mark.parametrize(
     "report",
     [
-        {"sample_size": 10, "max_drawdown": 0.1, "p_value": 0.01},
-        {"sample_size": 50, "max_drawdown": 0.3, "p_value": 0.01},
-        {"sample_size": 50, "max_drawdown": 0.1, "p_value": 0.2},
+        {"sample_size": MIN_SAMPLE - 1, "max_drawdown": MAX_MDD, "p_value": ALPHA - 0.01},
+        {"sample_size": MIN_SAMPLE, "max_drawdown": MAX_MDD + 0.01, "p_value": ALPHA - 0.01},
+        {"sample_size": MIN_SAMPLE, "max_drawdown": MAX_MDD, "p_value": ALPHA + 0.01},
     ],
 )
-def test_gate_rejects_when_any_threshold_fails(report):
+def test_approve_defaults_fail_edge_cases(report):
     assert not approve(report)
 
 
-def test_gate_respects_parameter_overrides():
-    report = {"sample_size": 50, "max_drawdown": 0.1, "p_value": 0.01}
-    assert not approve(report, min_sample=100)
+def test_approve_with_lenient_config():
+    cfg = CONFIG_DIR / "lenient.json"
+    report = {"sample_size": 5, "max_drawdown": 0.4, "p_value": 0.3}
+    assert approve(report, config_path=cfg)
 
 
-def test_gate_respects_config_file(tmp_path):
-    report = {"sample_size": 50, "max_drawdown": 0.1, "p_value": 0.01}
-    cfg = tmp_path / "config.json"
-    cfg.write_text(json.dumps({"MAX_MDD": 0.05}))
+def test_approve_with_strict_config():
+    cfg = CONFIG_DIR / "strict.json"
+    report = {"sample_size": MIN_SAMPLE, "max_drawdown": MAX_MDD, "p_value": ALPHA - 0.01}
     assert not approve(report, config_path=cfg)
-
-
-def test_gate_uses_default_config():
-    root = Path(__file__).resolve().parents[3]
-    cfg = json.loads((root / "fe" / "signoff" / "config.json").read_text())
-
-    failing = {
-        "sample_size": cfg["MIN_SAMPLE"] - 1,
-        "max_drawdown": cfg["MAX_MDD"] + 0.01,
-        "p_value": cfg["ALPHA"] + 0.01,
-    }
-    assert not approve(failing)
-
-    passing = {
-        "sample_size": cfg["MIN_SAMPLE"],
-        "max_drawdown": cfg["MAX_MDD"],
-        "p_value": cfg["ALPHA"] - 0.01,
-    }
-    assert approve(passing)


### PR DESCRIPTION
## Summary
- test signoff gate default thresholds and edge cases
- test JSON config overrides using fixture files

## Testing
- `ruff check tests/fe/signoff/test_gate.py`
- `pytest tests/fe/signoff/test_gate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b851c097048326bce5b53c57e08212