### PR TITLE
Gate strategies before packaging wheel

### DIFF
--- a/fe/export/build.py
+++ b/fe/export/build.py
@@ -1,9 +1,12 @@
 import argparse
+import json
 import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+from fe.signoff.gate import approve
 
 
 STRATEGIES = ["cross_pairs", "deadline_no", "maker", "rules_alpha"]
@@ -20,6 +23,18 @@ def build_wheel(version: str, strategies: list[str]) -> Path:
         Strategy module names to include.
     """
     repo_root = Path(__file__).resolve().parents[2]
+
+    reports_dir = repo_root / "reports"
+    for name in strategies:
+        report_path = reports_dir / f"{name}.json"
+        if not report_path.is_file():
+            raise FileNotFoundError(
+                f"Strategy report '{name}' not found at {report_path}"
+            )
+        report = json.loads(report_path.read_text())
+        if not approve(report):
+            raise SystemExit(f"Strategy '{name}' failed approval gate")
+
     dist_dir = repo_root / "dist"
     dist_dir.mkdir(exist_ok=True)
 

--- a/tests/fe/export/test_build_gate.py
+++ b/tests/fe/export/test_build_gate.py
@@ -1,0 +1,30 @@
+import json
+import shutil
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+import fe.export.build as build  # noqa: E402
+
+
+def test_build_aborts_when_gate_fails(monkeypatch):
+    root = Path(__file__).resolve().parents[3]
+    reports_dir = root / "reports"
+    dist_dir = root / "dist"
+    reports_dir.mkdir(exist_ok=True)
+    report_path = reports_dir / "maker.json"
+    report_path.write_text(json.dumps({"sample_size": 0}))
+
+    monkeypatch.setattr(build, "approve", lambda report: False)
+    try:
+        with pytest.raises(SystemExit, match="maker"):
+            build.build_wheel("0.0.0", ["maker"])
+    finally:
+        if report_path.exists():
+            report_path.unlink()
+        if reports_dir.exists() and not any(reports_dir.iterdir()):
+            reports_dir.rmdir()
+        if dist_dir.exists():
+            shutil.rmtree(dist_dir)


### PR DESCRIPTION
## Summary
- validate strategy reports with fe.signoff.gate.approve before building wheel
- stop packaging when a strategy fails the gate
- add integration test for gate failure during build

## Testing
- `ruff check fe/export/build.py tests/fe/export/test_build_gate.py`
- `pytest tests/fe/export/test_build_gate.py`


------
https://chatgpt.com/codex/tasks/task_e_68b851bfa8648326ba70ad99dde81f8e