### PR TITLE
Handle APR inputs as decimals in debt simulations

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -39,6 +39,7 @@ class DebtSimulationService
 {
     public const RANKING_HEURISTIC = 'interest_then_months';
     public const MAX_MONTHS = 600;
+    private const HIGH_APR_THRESHOLD = 0.10;
 
     /** @var StrategyInterface[] */
     private array $strategies;
@@ -63,7 +64,7 @@ class DebtSimulationService
      * @param string      $userId     The owning user identifier.
      * @param string|null $groupId    The user group identifier.
      * @param array $accounts   Array of accounts. Each entry must contain
-     *                          `account_id`, `balance` and `apr` (APR percentage)
+     *                          `account_id`, `balance` and `apr` (APR decimal)
      *                          and may contain `id`, `name` and `min_payment`.
      * @param float $budget     Total monthly amount available for debt payments.
      * @param int   $maxOptions Maximum number of plans to return.
@@ -95,7 +96,7 @@ class DebtSimulationService
                     return [
                         'name'        => (string) ($account['name'] ?? $account['id'] ?? $account['account_id']),
                         'balance'     => (float) $account['balance'],
-                        'rate'        => (float) $account['apr'] / 100,
+                        'rate'        => (float) $account['apr'],
                         'min_payment' => (float) ($account['min_payment'] ?? $account['minimum_payment'] ?? 0.0),
                     ];
                 }, $accounts);
@@ -224,7 +225,7 @@ class DebtSimulationService
 
         $recommendations   = [];
         foreach ($debts as $debt) {
-            if ($debt['rate'] >= 0.10) {
+            if ($debt['rate'] >= self::HIGH_APR_THRESHOLD) {
                 $recommendations[] = sprintf(
                     'Consider refinancing %s to lower the %.2f%% APR.',
                     $debt['name'],

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -76,13 +76,13 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             [
                 'account_id'      => (string) $account1->uuid,
                 'balance'         => 100.0,
-                'apr'             => 5.0,
+                'apr'             => 0.05,
                 'minimum_payment' => 0.0,
             ],
             [
                 'account_id'      => (string) $account2->uuid,
                 'balance'         => 200.0,
-                'apr'             => 3.0,
+                'apr'             => 0.03,
                 'minimum_payment' => 0.0,
             ],
         ];
@@ -176,13 +176,13 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             [
                 'account_id'      => (string) $account3->uuid,
                 'balance'         => 100.0,
-                'apr'             => 5.0,
+                'apr'             => 0.05,
                 'minimum_payment' => 0.0,
             ],
             [
                 'account_id'      => (string) $account4->uuid,
                 'balance'         => 200.0,
-                'apr'             => 3.0,
+                'apr'             => 0.03,
                 'minimum_payment' => 0.0,
             ],
         ];
@@ -206,7 +206,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             [
                 'account_id'       => (string) Str::uuid(),
                 'balance'          => 100.0,
-                'apr'              => 5.0,
+                'apr'              => 0.05,
                 'minimum_payment'  => 0.0,
             ],
         ];
@@ -264,7 +264,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             'accounts'       => [[
                 'account_id'       => (string) $foreign->uuid,
                 'balance'          => 100.0,
-                'apr'              => 5.0,
+                'apr'              => 0.05,
                 'minimum_payment'  => 0.0,
             ]],
             'monthly_budget' => 50.0,
@@ -310,7 +310,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             'accounts'       => [[
                 'account_id'       => (string) $account1->uuid,
                 'balance'          => 100.0,
-                'apr'              => 5.0,
+                'apr'              => 0.05,
                 'minimum_payment'  => 0.0,
             ]],
             'monthly_budget' => 50.0,

--- a/tests/unit/DebtSimulationTest.php
+++ b/tests/unit/DebtSimulationTest.php
@@ -34,7 +34,7 @@ final class DebtSimulationTest extends TestCase
         ]);
 
         $accounts = [
-            ['account_id' => 1, 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
         ];
         $budget = 200.0;
 
@@ -93,8 +93,8 @@ final class DebtSimulationTest extends TestCase
         ]);
 
         $accounts = [
-            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
-            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
+            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 0.05, 'min_payment' => 0.0],
         ];
         $budget = 300.0;
 
@@ -152,8 +152,8 @@ final class DebtSimulationTest extends TestCase
         ]);
 
         $accounts = [
-            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
-            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
+            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 0.05, 'min_payment' => 0.0],
         ];
         $budget = 300.0;
 

--- a/tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php
@@ -20,7 +20,7 @@ final class DebtSimulationNonConvergingTest extends TestCase
         $service = new DebtSimulationService();
 
         $accounts = [
-            ['account_id' => 1, 'balance' => 1000.0, 'apr' => 120.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'balance' => 1000.0, 'apr' => 1.20, 'min_payment' => 0.0],
         ];
         $budget = 50.0;
 

--- a/tests/unit/Modules/AI/DebtSimulationServiceAprConversionTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceAprConversionTest.php
@@ -22,7 +22,7 @@ final class DebtSimulationServiceAprConversionTest extends TestCase
         $userId   = 'user';
         $groupId  = 'group';
         $accounts = [
-            ['account_id' => 1, 'balance' => 1200.0, 'apr' => 12.0, 'minimum_payment' => 0.0],
+            ['account_id' => 1, 'balance' => 1200.0, 'apr' => 0.12, 'minimum_payment' => 0.0],
         ];
 
         $plans = $service->simulate($userId, $groupId, $accounts, 1200.0, 1);

--- a/tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php
@@ -47,7 +47,7 @@ final class DebtSimulationServiceBudgetTest extends TestCase
         $userId   = 'user';
         $groupId  = 'group';
         $accounts = [
-            ['account_id' => 1, 'balance' => 100.0, 'apr' => 5.0],
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 0.05],
         ];
 
         $plans = $service->simulate($userId, $groupId, $accounts, 50.0, 1);
@@ -87,13 +87,13 @@ final class DebtSimulationServiceBudgetTest extends TestCase
                 [
                     'account_id'      => (string) $account1->uuid,
                     'balance'         => 100.0,
-                    'apr'             => 5.0,
+                    'apr'             => 0.05,
                     'minimum_payment' => 60.0,
                 ],
                 [
                     'account_id'      => (string) $account2->uuid,
                     'balance'         => 100.0,
-                    'apr'             => 3.0,
+                    'apr'             => 0.03,
                     'minimum_payment' => 70.0,
                 ],
             ],

--- a/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
@@ -32,7 +32,7 @@ final class DebtSimulationServiceCachingTest extends TestCase
         $userIdB  = '01';
         $groupId  = '1';
         $accounts = [
-            ['account_id' => 1, 'balance' => 100.0, 'apr' => 5.0],
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 0.05],
         ];
         $budget     = 50.0;
         $maxOptions = 2;
@@ -61,8 +61,8 @@ final class DebtSimulationServiceCachingTest extends TestCase
         $userId   = '1';
         $groupId  = '1';
         $accounts = [
-            ['account_id' => 1, 'balance' => 100.0, 'apr' => 5.0],
-            ['account_id' => 2, 'balance' => 50.0, 'apr' => 3.0],
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 0.05],
+            ['account_id' => 2, 'balance' => 50.0, 'apr' => 0.03],
         ];
         $budget     = 50.0;
         $maxOptions = 2;

--- a/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
@@ -30,8 +30,8 @@ final class DebtSimulationServiceRankingTest extends TestCase
         $user    = $this->createAuthenticatedUser();
 
         $accounts = [
-            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
-            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
+            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 0.05, 'min_payment' => 0.0],
         ];
 
         $plans = $service->simulate((string) $user->id, '1', $accounts, 300.0, 3);
@@ -81,8 +81,8 @@ final class DebtSimulationServiceRankingTest extends TestCase
         $user    = $this->createAuthenticatedUser();
 
         $accounts = [
-            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
-            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
+            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 0.05, 'min_payment' => 0.0],
         ];
 
         $plans = $service->simulate((string) $user->id, '1', $accounts, 300.0, 2);
@@ -103,8 +103,8 @@ final class DebtSimulationServiceRankingTest extends TestCase
 
         $user       = $this->createAuthenticatedUser();
         $accounts   = [
-            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
-            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
+            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
+            ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 0.05, 'min_payment' => 0.0],
         ];
 
         $strategies = [SnowballStrategy::class, BalancedStrategy::class, AvalancheStrategy::class];

--- a/tests/unit/Modules/AI/MlStrategyTest.php
+++ b/tests/unit/Modules/AI/MlStrategyTest.php
@@ -96,8 +96,8 @@ namespace Tests\unit\Modules\AI {
             $user    = $this->createAuthenticatedUser();
 
             $accounts = [
-                ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 10.0, 'min_payment' => 0.0],
-                ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 5.0, 'min_payment' => 0.0],
+                ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
+                ['account_id' => 2, 'name' => 'Loan2', 'balance' => 500.0, 'apr' => 0.05, 'min_payment' => 0.0],
             ];
 
             $plans = $service->simulate((string) $user->id, '1', $accounts, 300.0, 4);

--- a/tests/unit/Modules/AI/UserScopedCacheGroupTest.php
+++ b/tests/unit/Modules/AI/UserScopedCacheGroupTest.php
@@ -32,7 +32,7 @@ final class UserScopedCacheGroupTest extends TestCase
         $groupIdA = '1';
         $groupIdB = '2';
         $accounts = [
-            ['account_id' => 1, 'balance' => 100.0, 'apr' => 5.0],
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 0.05],
         ];
         $budget     = 50.0;
         $maxOptions = 2;


### PR DESCRIPTION
## Summary
- Drop percent conversion so APR inputs are treated as decimal rates
- Introduce constant threshold for high APR refinance recommendations
- Update unit and feature tests to supply decimal APR values

## Testing
- `composer unit-test`
- `vendor/bin/phpunit tests/Feature/DebtSimulationApiTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8607e7f9c83269b4572bd82df2956