### PR TITLE
Extend debt simulation cache key with heuristic and strategies

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -79,8 +79,18 @@ class DebtSimulationService
         usort($accounts, static function (array $a, array $b): int {
             return ($a['account_id'] ?? 0) <=> ($b['account_id'] ?? 0);
         });
+        $strategyClasses = array_map(
+            static fn (StrategyInterface $strategy): string => get_class($strategy),
+            $this->strategies
+        );
 
-        $hash     = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
+        $hash     = hash('sha256', serialize([
+            $accounts,
+            $budget,
+            $maxOptions,
+            $this->rankingHeuristic,
+            $strategyClasses,
+        ]));
 
         $cacheKey = 'debt-sim-' . $hash;
         $ttl      = (int) config('ai.debt_simulation_cache_ttl', 3600);

--- a/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php
@@ -38,8 +38,9 @@ final class DebtSimulationServiceCachingTest extends TestCase
         $maxOptions = 2;
 
         $service->simulate($userIdA, $groupId, $accounts, $budget, $maxOptions);
-
-        $hash       = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
+        $heuristic  = config('ai.ranking_heuristic');
+        $strategies = config('ai.debt_simulation_strategies', []);
+        $hash       = hash('sha256', serialize([$accounts, $budget, $maxOptions, $heuristic, $strategies]));
         $cacheKeyA  = sprintf('u:%s:g:%s:debt-sim-%s', $userIdA, $groupId, $hash);
         self::assertTrue(Cache::has($cacheKeyA));
 
@@ -79,11 +80,45 @@ final class DebtSimulationServiceCachingTest extends TestCase
 
         self::assertEquals($resultA, $resultB);
 
-        $hash             = hash('sha256', serialize([$originalAccounts, $budget, $maxOptions]));
+        $heuristic        = config('ai.ranking_heuristic');
+        $strategies       = config('ai.debt_simulation_strategies', []);
+        $hash             = hash('sha256', serialize([$originalAccounts, $budget, $maxOptions, $heuristic, $strategies]));
         $cacheKey         = sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupId, $hash);
-        $hashShuffled     = hash('sha256', serialize([$shuffled, $budget, $maxOptions]));
+        $hashShuffled     = hash('sha256', serialize([$shuffled, $budget, $maxOptions, $heuristic, $strategies]));
         $cacheKeyShuffled = sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupId, $hashShuffled);
         self::assertTrue(Cache::has($cacheKey));
         self::assertFalse(Cache::has($cacheKeyShuffled));
+    }
+
+    public function testInvalidatesCacheWhenHeuristicChanges(): void
+    {
+        Cache::flush();
+        $userId   = '1';
+        $groupId  = '1';
+        $accounts = [
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 5.0],
+        ];
+        $budget     = 50.0;
+        $maxOptions = 2;
+
+        config(['ai.ranking_heuristic' => 'interest_then_months']);
+        $serviceA = new DebtSimulationService();
+        $resultA  = $serviceA->simulate($userId, $groupId, $accounts, $budget, $maxOptions);
+        $strategies = config('ai.debt_simulation_strategies', []);
+        $hashA      = hash('sha256', serialize([$accounts, $budget, $maxOptions, 'interest_then_months', $strategies]));
+        $cacheKeyA  = sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupId, $hashA);
+        self::assertTrue(Cache::has($cacheKeyA));
+
+        config(['ai.ranking_heuristic' => 'months_then_interest']);
+        $serviceB = new DebtSimulationService();
+        $resultB  = $serviceB->simulate($userId, $groupId, $accounts, $budget, $maxOptions);
+        $hashB     = hash('sha256', serialize([$accounts, $budget, $maxOptions, 'months_then_interest', $strategies]));
+        $cacheKeyB = sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupId, $hashB);
+
+        self::assertTrue(Cache::has($cacheKeyB));
+        self::assertNotEquals($cacheKeyA, $cacheKeyB);
+        self::assertNotEquals($resultA, $resultB);
+
+        config(['ai.ranking_heuristic' => DebtSimulationService::RANKING_HEURISTIC]);
     }
 }

--- a/tests/unit/Modules/AI/UserScopedCacheGroupTest.php
+++ b/tests/unit/Modules/AI/UserScopedCacheGroupTest.php
@@ -40,7 +40,9 @@ final class UserScopedCacheGroupTest extends TestCase
         $service->simulate($userId, $groupIdA, $accounts, $budget, $maxOptions);
         $service->simulate($userId, $groupIdB, $accounts, $budget, $maxOptions);
 
-        $hash      = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
+        $heuristic = config('ai.ranking_heuristic');
+        $strategies = config('ai.debt_simulation_strategies', []);
+        $hash      = hash('sha256', serialize([$accounts, $budget, $maxOptions, $heuristic, $strategies]));
         $cacheKeyA = sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupIdA, $hash);
         $cacheKeyB = sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupIdB, $hash);
 


### PR DESCRIPTION
## Summary
- include ranking heuristic and strategy class names in cache key generation
- ensure cache key hashes reflect ranking heuristic and strategies
- add coverage for cache invalidation when heuristic changes

## Testing
- `vendor/bin/phpstan analyse app/Modules/AI/Simulations/DebtSimulationService.php tests/unit/Modules/AI/DebtSimulationServiceCachingTest.php tests/unit/Modules/AI/UserScopedCacheGroupTest.php --no-progress --memory-limit=1G`
- `composer unit-test`

------
https://chatgpt.com/codex/tasks/task_e_68b8607f28848326876944102f62dd6f