### PR TITLE
Add configurable threshold and Avalanche fallback for ML strategy

### DIFF
--- a/app/Modules/AI/Simulations/Strategies/MlStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/MlStrategy.php
@@ -53,6 +53,7 @@ class MlStrategy implements StrategyInterface
     protected function infer(array $features): ?int
     {
         $modelPath = config('ai.ml_model_path');
+        $threshold = (float) config('ai.ml_model_threshold', 0.0);
 
         if (!is_string($modelPath) || !is_file($modelPath)) {
             return null;
@@ -68,8 +69,9 @@ class MlStrategy implements StrategyInterface
             $predictions = $result[0] ?? $result['output'] ?? null;
 
             if (is_array($predictions) && [] !== $predictions) {
-                $index = array_search(max($predictions), $predictions, true);
-                if (false !== $index) {
+                $max    = max($predictions);
+                $index  = array_search($max, $predictions, true);
+                if (false !== $index && $max >= $threshold) {
                     return (int) $index;
                 }
             }
@@ -88,6 +90,8 @@ class MlStrategy implements StrategyInterface
             return $prediction;
         }
 
-        return null;
+        $fallback = new AvalancheStrategy();
+
+        return $fallback->selectTargetDebt($debts);
     }
 }

--- a/config/ai.php
+++ b/config/ai.php
@@ -9,5 +9,6 @@ return [
         \FireflyIII\Modules\AI\Simulations\Strategies\BalancedStrategy::class,
         \FireflyIII\Modules\AI\Simulations\Strategies\MlStrategy::class,
     ],
-    'ml_model_path' => env('ML_MODEL_PATH', storage_path('app/ai/ml_model.onnx')),
+    'ml_model_path'      => env('ML_MODEL_PATH', storage_path('app/ai/ml_model.onnx')),
+    'ml_model_threshold' => env('ML_MODEL_THRESHOLD', 0.5),
 ];

--- a/tests/unit/Modules/AI/MlStrategyTest.php
+++ b/tests/unit/Modules/AI/MlStrategyTest.php
@@ -47,8 +47,9 @@ namespace Tests\unit\Modules\AI {
         public function testSuccessfulInference(): void
         {
             $original = config('ai.ml_model_path');
+            $originalThreshold = config('ai.ml_model_threshold');
             $modelPath = tempnam(sys_get_temp_dir(), 'model');
-            config(['ai.ml_model_path' => $modelPath]);
+            config(['ai.ml_model_path' => $modelPath, 'ai.ml_model_threshold' => 0.5]);
 
             \ONNXRuntime\InferenceSession::$shouldThrow = false;
             \ONNXRuntime\InferenceSession::$output = [[0.1, 0.7, 0.2]];
@@ -64,28 +65,59 @@ namespace Tests\unit\Modules\AI {
 
             self::assertSame(1, $result);
 
-            config(['ai.ml_model_path' => $original]);
+            \ONNXRuntime\InferenceSession::$output = [[0.0]];
+
+            config(['ai.ml_model_path' => $original, 'ai.ml_model_threshold' => $originalThreshold]);
         }
 
         public function testInferenceFallbackOnError(): void
         {
-            $original = config('ai.ml_model_path');
+            $original           = config('ai.ml_model_path');
+            $originalThreshold  = config('ai.ml_model_threshold');
             $modelPath = tempnam(sys_get_temp_dir(), 'model');
-            config(['ai.ml_model_path' => $modelPath]);
+            config(['ai.ml_model_path' => $modelPath, 'ai.ml_model_threshold' => 0.5]);
 
             \ONNXRuntime\InferenceSession::$shouldThrow = true;
 
             $strategy = new MlStrategy();
             $debts    = [
                 ['balance' => 100.0, 'rate' => 1.0, 'min_payment' => 10.0],
+                ['balance' => 200.0, 'rate' => 2.0, 'min_payment' => 20.0],
             ];
 
             $result = $strategy->selectTargetDebt($debts);
 
-            self::assertNull($result);
+            self::assertSame(1, $result);
 
             \ONNXRuntime\InferenceSession::$shouldThrow = false;
-            config(['ai.ml_model_path' => $original]);
+            \ONNXRuntime\InferenceSession::$output      = [[0.0]];
+            config(['ai.ml_model_path' => $original, 'ai.ml_model_threshold' => $originalThreshold]);
+        }
+
+        public function testInferenceFallbackOnLowConfidence(): void
+        {
+            $original           = config('ai.ml_model_path');
+            $originalThreshold  = config('ai.ml_model_threshold');
+            $modelPath = tempnam(sys_get_temp_dir(), 'model');
+            config(['ai.ml_model_path' => $modelPath, 'ai.ml_model_threshold' => 0.8]);
+
+            \ONNXRuntime\InferenceSession::$shouldThrow = false;
+            \ONNXRuntime\InferenceSession::$output      = [[0.4, 0.3, 0.3]];
+
+            $strategy = new MlStrategy();
+            $debts    = [
+                ['balance' => 100.0, 'rate' => 1.0, 'min_payment' => 10.0],
+                ['balance' => 200.0, 'rate' => 2.0, 'min_payment' => 20.0],
+                ['balance' => 50.0, 'rate' => 0.5, 'min_payment' => 5.0],
+            ];
+
+            $result = $strategy->selectTargetDebt($debts);
+
+            self::assertSame(1, $result);
+
+            \ONNXRuntime\InferenceSession::$output = [[0.0]];
+
+            config(['ai.ml_model_path' => $original, 'ai.ml_model_threshold' => $originalThreshold]);
         }
 
         public function testStrategyIsInvokedAndRankedWithAnnotations(): void
@@ -110,9 +142,9 @@ namespace Tests\unit\Modules\AI {
             self::assertNotFalse($mlIndex);
             $mlPlan = $plans[$mlIndex];
 
-            // ensure ml strategy ranked last and is marked non-converging
-            self::assertSame($mlIndex + 1, $mlPlan['rank']);
-            self::assertSame('non_converging', $mlPlan['status']);
+            // ensure ml strategy produced a converging plan
+            self::assertIsInt($mlPlan['rank']);
+            self::assertSame('ok', $mlPlan['status']);
 
             // cost-of-deviation relative to best plan
             $bestPlan         = $plans[0];


### PR DESCRIPTION
## Summary
- allow configuring ML model threshold via `ml_model_threshold`
- fall back to AvalancheStrategy when ML inference fails or lacks confidence
- extend MlStrategy tests for success and fallback scenarios

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpstan analyse --memory-limit=512M app/Modules/AI/Simulations/Strategies/MlStrategy.php tests/unit/Modules/AI/MlStrategyTest.php`
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpunit tests/unit/Modules/AI/MlStrategyTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bef75e65388326a07e033d8589e4c2