### PR TITLE
Enhance Polymarket ETL logging with retry tests

### DIFF
--- a/fe/data/polymarket/etl.py
+++ b/fe/data/polymarket/etl.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -48,15 +49,22 @@ _retries = retry.Retry(
     backoff_factor=1,
     status_forcelist=[429, 500, 502, 503, 504],
     allowed_methods=["GET"],
+    raise_on_status=False,
 )
 _adapter = HTTPAdapter(max_retries=_retries)
 _session.mount("https://", _adapter)
 _session.mount("http://", _adapter)
 
+logger = logging.getLogger(__name__)
+
 
 def _get(url: str, params: Dict[str, Any] | None = None) -> Any:
-    resp = _session.get(url, params=params, timeout=30)
-    resp.raise_for_status()
+    try:
+        resp = _session.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+    except Exception:
+        logger.exception("GET request failed for %s", url)
+        raise
     if resp.headers.get("content-type", "").startswith("application/json"):
         return resp.json()
     return resp.text
@@ -108,6 +116,7 @@ def fetch_price_history(market_id: str) -> List[Dict[str, Any]]:
             {"resolution": "d"},
         )
     except Exception:
+        logger.exception("Failed to fetch price history for %s", market_id)
         return []
 
 
@@ -116,6 +125,7 @@ def fetch_order_book(market_id: str) -> Dict[str, Any]:
     try:
         return _get(f"{CLOB_URL}/markets/{market_id}/book")
     except Exception:
+        logger.exception("Failed to fetch order book for %s", market_id)
         return {}
 
 
@@ -129,6 +139,9 @@ def fetch_clarification_resolution_events(
             {"market": market_id},
         )
     except Exception:
+        logger.exception(
+            "Failed to fetch clarification/resolution events for %s", market_id
+        )
         return []
 
 

--- a/tests/fe/test_polymarket_etl.py
+++ b/tests/fe/test_polymarket_etl.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from fe.data.polymarket import etl
+
+
+def test_get_retries():
+    class Handler(BaseHTTPRequestHandler):
+        attempts = 0
+
+        def do_GET(self):
+            Handler.attempts += 1
+            if Handler.attempts < 3:
+                self.send_response(500)
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b"{\"ok\": true}")
+
+        def log_message(self, format, *args):  # pragma: no cover
+            pass
+
+    server = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    try:
+        url = f"http://localhost:{server.server_port}/test"
+        result = etl._get(url)
+        assert result == {"ok": True}
+        assert Handler.attempts == 3
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_save_market_partition_paths(tmp_path, monkeypatch):
+    market = {
+        "id": "1",
+        "endDate": "2020-11-04T00:00:00Z",
+        "category": "politics",
+        "question": "Will it rain?",
+        "outcomes": ["Yes", "No"],
+        "createdAt": "2020-01-01T00:00:00Z",
+    }
+    monkeypatch.setattr(etl, "fetch_price_history", lambda _id: [])
+    monkeypatch.setattr(etl, "fetch_order_book", lambda _id: {})
+    monkeypatch.setattr(etl, "fetch_clarification_resolution_events", lambda _id: [])
+    etl.save_market(market, output_dir=tmp_path)
+    expected = (
+        tmp_path
+        / "event_date=2020-11-04"
+        / "category=politics"
+        / "market_1.parquet"
+    )
+    assert expected.exists()


### PR DESCRIPTION
## Summary
- add error logging and raise-on-status retry behavior to Polymarket ETL helper functions
- test `_get` retry logic using a mock HTTP server
- verify parquet partition paths for saved markets

## Testing
- `ruff check fe/data/polymarket/etl.py tests/fe/test_polymarket_etl.py tests/fe/data/test_etl.py tests/python/test_polymarket_events.py`
- `pytest tests/fe/test_polymarket_etl.py tests/fe/data/test_etl.py tests/python/test_polymarket_events.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03249bbb4832689da4e763ea0e3b1