### PR TITLE
Flush cache on user group membership changes

### DIFF
--- a/app/Listeners/UserGroupMembershipChanged.php
+++ b/app/Listeners/UserGroupMembershipChanged.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FireflyIII\Listeners;
+
+use FireflyIII\Models\GroupMembership;
+use FireflyIII\Support\Cache\UserScopedCache;
+
+class UserGroupMembershipChanged
+{
+    public function handle(GroupMembership $membership): void
+    {
+        $currentUserId  = is_numeric($membership->user_id) ? (int) $membership->user_id : null;
+        $currentGroupId = is_numeric($membership->user_group_id) ? (int) $membership->user_group_id : null;
+
+        $this->flushFor($currentUserId, $currentGroupId);
+
+        $originalUserId  = $membership->getOriginal('user_id');
+        $originalGroupId = $membership->getOriginal('user_group_id');
+
+        $originalUserId  = is_numeric($originalUserId) ? (int) $originalUserId : null;
+        $originalGroupId = is_numeric($originalGroupId) ? (int) $originalGroupId : null;
+
+        if ($originalUserId !== $currentUserId || $originalGroupId !== $currentGroupId) {
+            $this->flushFor($originalUserId, $originalGroupId);
+        }
+    }
+
+    private function flushFor(?int $userId, ?int $groupId): void
+    {
+        if (null === $userId) {
+            return;
+        }
+
+        UserScopedCache::flush((string) $userId, null === $groupId ? null : (string) $groupId);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -60,6 +60,7 @@ use FireflyIII\Events\UpdatedTransactionGroup;
 use FireflyIII\Events\UserChangedEmail;
 use FireflyIII\Events\WarnUserAboutBill;
 use FireflyIII\Listeners\FlushDebtSimulationCache;
+use FireflyIII\Listeners\UserGroupMembershipChanged;
 use FireflyIII\Handlers\Observer\AccountObserver;
 use FireflyIII\Handlers\Observer\AttachmentObserver;
 use FireflyIII\Handlers\Observer\AutoBudgetObserver;
@@ -206,6 +207,15 @@ class EventServiceProvider extends ServiceProvider
             ],
             'eloquent.deleted: FireflyIII\User' => [
                 FlushDebtSimulationCache::class,
+            ],
+            'eloquent.created: FireflyIII\Models\GroupMembership' => [
+                UserGroupMembershipChanged::class,
+            ],
+            'eloquent.updated: FireflyIII\Models\GroupMembership' => [
+                UserGroupMembershipChanged::class,
+            ],
+            'eloquent.deleted: FireflyIII\Models\GroupMembership' => [
+                UserGroupMembershipChanged::class,
             ],
 
             // bill related events:

--- a/tests/integration/AI/UserGroupMembershipCacheInvalidationTest.php
+++ b/tests/integration/AI/UserGroupMembershipCacheInvalidationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\integration\AI;
+
+use FireflyIII\Models\GroupMembership;
+use FireflyIII\Support\Cache\UserScopedCache;
+use Illuminate\Support\Facades\Cache;
+use Tests\integration\TestCase;
+
+/**
+ * @group integration-test
+ * @group ai
+ *
+ * @internal
+ */
+final class UserGroupMembershipCacheInvalidationTest extends TestCase
+{
+    public function testFlushesCacheWhenMembershipUpdated(): void
+    {
+        Cache::flush();
+
+        UserScopedCache::remember('1', '1', 'debt-sim-test', fn() => 'cached', 3600);
+        UserScopedCache::remember('1', '2', 'debt-sim-test', fn() => 'cached', 3600);
+
+        $oldKey = 'u:1:g:1:debt-sim-test';
+        $newKey = 'u:1:g:2:debt-sim-test';
+
+        self::assertTrue(Cache::has($oldKey));
+        self::assertTrue(Cache::has($newKey));
+
+        $membership = new GroupMembership();
+        $membership->setRawAttributes([
+            'user_id'       => 1,
+            'user_group_id' => 1,
+        ], true);
+        $membership->exists         = true;
+        $membership->user_group_id  = 2;
+
+        event('eloquent.updated: ' . GroupMembership::class, $membership);
+
+        self::assertFalse(Cache::has($oldKey));
+        self::assertFalse(Cache::has($newKey));
+    }
+}


### PR DESCRIPTION
## Summary
- add a listener that flushes user scoped caches when group memberships change
- register the listener for eloquent membership events to keep caches in sync
- cover the listener with an integration test that simulates a group reassignment

## Testing
- vendor/bin/phpunit tests/integration/AI/UserGroupMembershipCacheInvalidationTest.php
- vendor/bin/phpstan analyse app/Listeners/UserGroupMembershipChanged.php tests/integration/AI/UserGroupMembershipCacheInvalidationTest.php --no-progress --memory-limit=512M

------
https://chatgpt.com/codex/tasks/task_e_68c96efc7d6c83269b396b94f182d388