### PR TITLE
Adjust rule objectivity fallback to unknown

### DIFF
--- a/fe/features/rule_objectivity.py
+++ b/fe/features/rule_objectivity.py
@@ -73,8 +73,8 @@ def score_rule_objectivity(rule: Optional[str]) -> str:
         return "ambiguous"
     if clear:
         return "clear"
-    # Default to "clear" when text exists but heuristics find nothing
-    return "clear"
+    # Default to "unknown" when text exists but heuristics find nothing
+    return "unknown"
 
 
 def batch_score(rules: Iterable[Optional[str]]) -> list[str]:

--- a/tests/test_rule_objectivity.py
+++ b/tests/test_rule_objectivity.py
@@ -34,11 +34,16 @@ def test_score_numeric_sets_clear():
     assert score_rule_objectivity(rule) == "clear"
 
 
-def test_score_default_clear():
+def test_score_default_unknown():
     rule = "ordinary text without keywords"
-    assert score_rule_objectivity(rule) == "clear"
+    assert score_rule_objectivity(rule) == "unknown"
 
 
 def test_batch_score():
-    rules = [None, "Outcome may be unknown", "Outcome will be official"]
-    assert batch_score(rules) == ["unknown", "ambiguous", "clear"]
+    rules = [
+        None,
+        "ordinary text without keywords",
+        "Outcome may be unknown",
+        "Outcome will be official",
+    ]
+    assert batch_score(rules) == ["unknown", "unknown", "ambiguous", "clear"]


### PR DESCRIPTION
## Summary
- update rule objectivity scoring to return "unknown" when heuristics find no match
- extend unit tests to cover the fallback behaviour and batch scoring output

## Testing
- flake8 fe/features/rule_objectivity.py tests/test_rule_objectivity.py --extend-ignore=E501
- pytest tests/test_rule_objectivity.py

------
https://chatgpt.com/codex/tasks/task_e_68c97483dcc883268483890e99e3b480