### PR TITLE
Cache ONNX runtime session in ML strategy

### DIFF
--- a/app/Modules/AI/Simulations/Strategies/MlStrategy.php
+++ b/app/Modules/AI/Simulations/Strategies/MlStrategy.php
@@ -9,6 +9,13 @@ namespace FireflyIII\Modules\AI\Simulations\Strategies;
  */
 class MlStrategy implements StrategyInterface
 {
+    /**
+     * @var \ONNXRuntime\InferenceSession|null
+     */
+    private static $session = null;
+
+    private static ?string $sessionModelPath = null;
+
     public function getName(): string
     {
         return 'ml';
@@ -56,15 +63,24 @@ class MlStrategy implements StrategyInterface
         $threshold = (float) config('ai.ml_model_threshold', 0.0);
 
         if (!is_string($modelPath) || !is_file($modelPath)) {
+            self::$session = null;
+            self::$sessionModelPath = null;
             return null;
         }
 
         if (!class_exists('\\ONNXRuntime\\InferenceSession')) {
+            self::$session = null;
+            self::$sessionModelPath = null;
             return null;
         }
 
         try {
-            $session     = new \ONNXRuntime\InferenceSession($modelPath);
+            if (null === self::$session || $modelPath !== self::$sessionModelPath) {
+                self::$session           = new \ONNXRuntime\InferenceSession($modelPath);
+                self::$sessionModelPath  = $modelPath;
+            }
+
+            $session     = self::$session;
             $result      = $session->run(['input' => $features]);
             $predictions = $result[0] ?? $result['output'] ?? null;
 
@@ -76,6 +92,8 @@ class MlStrategy implements StrategyInterface
                 }
             }
         } catch (\Throwable $e) {
+            self::$session = null;
+            self::$sessionModelPath = null;
             report($e);
         }
 

--- a/tests/unit/Modules/AI/MlStrategyTest.php
+++ b/tests/unit/Modules/AI/MlStrategyTest.php
@@ -7,10 +7,12 @@ namespace ONNXRuntime {
     {
         public static bool $shouldThrow = false;
         public static array $output = [[0.0]];
+        public static int $instances = 0;
         private string $path;
 
         public function __construct(string $path)
         {
+            self::$instances++;
             $this->path = $path;
         }
 
@@ -35,6 +37,7 @@ namespace Tests\unit\Modules\AI {
     use FireflyIII\Modules\AI\Simulations\Strategies\MlStrategy;
     use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
     use Illuminate\Support\Facades\Cache;
+    use ReflectionClass;
     use Tests\integration\TestCase;
     use function Safe\tempnam;
 
@@ -44,6 +47,29 @@ namespace Tests\unit\Modules\AI {
      */
     final class MlStrategyTest extends TestCase
     {
+        protected function tearDown(): void
+        {
+            parent::tearDown();
+
+            \ONNXRuntime\InferenceSession::$shouldThrow = false;
+            \ONNXRuntime\InferenceSession::$output      = [[0.0]];
+            \ONNXRuntime\InferenceSession::$instances   = 0;
+
+            $reflection = new ReflectionClass(MlStrategy::class);
+
+            if ($reflection->hasProperty('session')) {
+                $property = $reflection->getProperty('session');
+                $property->setAccessible(true);
+                $property->setValue(null);
+            }
+
+            if ($reflection->hasProperty('sessionModelPath')) {
+                $property = $reflection->getProperty('sessionModelPath');
+                $property->setAccessible(true);
+                $property->setValue(null);
+            }
+        }
+
         public function testSuccessfulInference(): void
         {
             $original = config('ai.ml_model_path');
@@ -66,6 +92,34 @@ namespace Tests\unit\Modules\AI {
             self::assertSame(1, $result);
 
             \ONNXRuntime\InferenceSession::$output = [[0.0]];
+
+            config(['ai.ml_model_path' => $original, 'ai.ml_model_threshold' => $originalThreshold]);
+        }
+
+        public function testInferenceSessionIsReusedAcrossCalls(): void
+        {
+            $original          = config('ai.ml_model_path');
+            $originalThreshold = config('ai.ml_model_threshold');
+            $modelPath         = tempnam(sys_get_temp_dir(), 'model');
+            config(['ai.ml_model_path' => $modelPath, 'ai.ml_model_threshold' => 0.5]);
+
+            \ONNXRuntime\InferenceSession::$shouldThrow = false;
+            \ONNXRuntime\InferenceSession::$output      = [[0.8, 0.1, 0.1]];
+            \ONNXRuntime\InferenceSession::$instances   = 0;
+
+            $strategy = new MlStrategy();
+            $debts    = [
+                ['balance' => 100.0, 'rate' => 1.0, 'min_payment' => 10.0],
+                ['balance' => 200.0, 'rate' => 2.0, 'min_payment' => 20.0],
+                ['balance' => 50.0, 'rate' => 3.0, 'min_payment' => 5.0],
+            ];
+
+            $firstResult  = $strategy->selectTargetDebt($debts);
+            $secondResult = $strategy->selectTargetDebt($debts);
+
+            self::assertSame(0, $firstResult);
+            self::assertSame($firstResult, $secondResult);
+            self::assertSame(1, \ONNXRuntime\InferenceSession::$instances);
 
             config(['ai.ml_model_path' => $original, 'ai.ml_model_threshold' => $originalThreshold]);
         }


### PR DESCRIPTION
## Summary
- add a cached ONNX InferenceSession to the ML strategy and guard reuse with model path tracking
- reset the cached session when prerequisites fail or inference throws
- extend the ML strategy unit test double to count session instantiations and assert reuse with cleanup

## Testing
- APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpunit tests/unit/Modules/AI/MlStrategyTest.php
- APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpstan analyse app/Modules/AI/Simulations/Strategies/MlStrategy.php --no-progress --memory-limit=1G


------
https://chatgpt.com/codex/tasks/task_e_68c974831b488326b105daea55ee0f76