### PR TITLE
Ensure debt simulation respects max options

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -68,6 +68,10 @@ class DebtSimulationService
      *                          and may contain `id`, `name` and `min_payment`.
      * @param float $budget     Total monthly amount available for debt payments.
      * @param int   $maxOptions Maximum number of plans to return.
+     *                          Converging plans are prioritised and only if
+     *                          capacity remains will non-converging plans be
+     *                          appended with their convergence status so the
+     *                          overall total never exceeds the requested limit.
      *
      * @return array<int, array<string, mixed>>
      */
@@ -139,11 +143,23 @@ class DebtSimulationService
                     }
                 }
 
+                // Converging plans are always ranked before non-converging plans.
                 usort($convergingPlans, static function (array $a, array $b): int {
                     return [$a['total_interest'], $a['months']] <=> [$b['total_interest'], $b['months']];
                 });
 
                 $convergingPlans = array_slice($convergingPlans, 0, $maxOptions);
+
+                // Non-converging plans are only returned when there is remaining capacity after
+                // selecting the best converging candidates. They are ranked using the same
+                // heuristic but always trail the converging entries so the total never exceeds
+                // the requested maximum.
+                usort($nonConvergingPlans, static function (array $a, array $b): int {
+                    return [$a['total_interest'], $a['months']] <=> [$b['total_interest'], $b['months']];
+                });
+
+                $availableSlots    = max(0, $maxOptions - count($convergingPlans));
+                $nonConvergingPlans = array_slice($nonConvergingPlans, 0, $availableSlots);
 
                 $plans = array_merge($convergingPlans, $nonConvergingPlans);
 

--- a/tests/integration/AI/DebtSimulationCacheTtlTest.php
+++ b/tests/integration/AI/DebtSimulationCacheTtlTest.php
@@ -32,7 +32,16 @@ final class DebtSimulationCacheTtlTest extends TestCase
 
         $service->simulate($userId, $groupId, $accounts, $budget, $maxOptions);
 
-        $hash     = hash('sha256', serialize([$accounts, $budget, $maxOptions]));
+        $normalizedAccounts = $accounts;
+        usort($normalizedAccounts, static function (array $a, array $b): int {
+            return ($a['account_id'] ?? 0) <=> ($b['account_id'] ?? 0);
+        });
+        $heuristic = (string) config('ai.ranking_heuristic', DebtSimulationService::RANKING_HEURISTIC);
+        $strategies = array_map(
+            static fn (string $strategyClass): string => get_class(app($strategyClass)),
+            config('ai.debt_simulation_strategies', [])
+        );
+        $hash     = hash('sha256', serialize([$normalizedAccounts, $budget, $maxOptions, $heuristic, $strategies]));
         $cacheKey = sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupId, $hash);
         self::assertTrue(Cache::has($cacheKey));
 

--- a/tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationNonConvergingTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\unit\Modules\AI;
 
 use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use FireflyIII\Modules\AI\Simulations\Strategies\AvalancheStrategy;
+use FireflyIII\Modules\AI\Simulations\Strategies\StrategyInterface;
 use Illuminate\Support\Facades\Cache;
 use Tests\integration\TestCase;
 
@@ -29,5 +31,48 @@ final class DebtSimulationNonConvergingTest extends TestCase
         self::assertSame('non_converging', $plans[0]['status']);
         self::assertFalse($plans[0]['is_optimal']);
         self::assertLessThanOrEqual(DebtSimulationService::MAX_MONTHS, $plans[0]['months']);
+    }
+
+    public function testPlansDoNotExceedMaxOptions(): void
+    {
+        Cache::flush();
+        $service = new DebtSimulationService([
+            AvalancheStrategy::class,
+            PassiveNonConvergingTestStrategy::class,
+        ]);
+
+        $accounts = [
+            ['account_id' => 1, 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
+        ];
+        $budget     = 100.0;
+        $maxOptions = 1;
+
+        $plans = $service->simulate('user', 'group', $accounts, $budget, $maxOptions);
+
+        self::assertCount($maxOptions, $plans);
+        self::assertSame('avalanche', $plans[0]['strategy']);
+        self::assertSame('ok', $plans[0]['status']);
+    }
+}
+
+final class PassiveNonConvergingTestStrategy implements StrategyInterface
+{
+    public function getName(): string
+    {
+        return 'passive_non_converging_test';
+    }
+
+    public function getExplanation(): string
+    {
+        return 'Leaves extra funds unused so the plan fails to converge.';
+    }
+
+    public function reset(): void
+    {
+    }
+
+    public function selectTargetDebt(array $debts): ?int
+    {
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- prioritise converging debt payoff plans and only append a capped number of non-converging plans while documenting the behaviour
- update the debt simulation cache TTL integration test to mirror the production cache key inputs
- add a unit test that exercises mixed convergence outcomes to verify the response never exceeds the requested max options

## Testing
- vendor/bin/phpunit --filter DebtSimulation

------
https://chatgpt.com/codex/tasks/task_e_68cd6573dda48326a8b53efad00559a1