### PR TITLE
Handle faster debt plans in tradeoff messaging

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -211,17 +211,39 @@ class DebtSimulationService
                         'time_months' => $plan['months'] - $bestMonths,
                     ];
 
-                    $tradeoffString = $plan['is_optimal']
-                        ? 'no tradeoffs'
-                        : sprintf(
-                            'loses %.2f in interest savings and %d more months',
-                            $plan['cost_of_deviation']['currency'],
-                            $plan['cost_of_deviation']['time_months']
-                        );
+                    $currencyDeviation = (float) $plan['cost_of_deviation']['currency'];
+                    $monthsDeviation   = (int) $plan['cost_of_deviation']['time_months'];
 
-                    $rankingReason = $plan['is_optimal']
-                        ? 'maximizes interest savings'
-                        : ('non_converging' === $status ? 'plan does not converge' : 'less interest saved or longer duration');
+                    if ($plan['is_optimal']) {
+                        $tradeoffString = 'no tradeoffs';
+                        $rankingReason  = 'maximizes interest savings';
+                    } else {
+                        if ($monthsDeviation < 0) {
+                            $tradeoffString = sprintf(
+                                'loses %.2f in interest savings but %d fewer months',
+                                $currencyDeviation,
+                                abs($monthsDeviation)
+                            );
+                            $rankingReason = 'less interest saved despite faster payoff';
+                        } elseif (0 === $monthsDeviation) {
+                            $tradeoffString = sprintf(
+                                'loses %.2f in interest savings with same payoff time',
+                                $currencyDeviation
+                            );
+                            $rankingReason = 'less interest saved with same payoff time';
+                        } else {
+                            $tradeoffString = sprintf(
+                                'loses %.2f in interest savings and %d more months',
+                                $currencyDeviation,
+                                $monthsDeviation
+                            );
+                            $rankingReason = 'less interest saved or longer duration';
+                        }
+
+                        if ('non_converging' === $status) {
+                            $rankingReason = 'plan does not converge';
+                        }
+                    }
 
                     $heuristicScores = [];
                     foreach ($this->rankingFields as $field) {

--- a/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
@@ -91,6 +91,38 @@ final class DebtSimulationServiceRankingTest extends TestCase
         }
     }
 
+    public function testFasterNonOptimalPlanUsesFewerMonthsMessaging(): void
+    {
+        Cache::flush();
+        config(['ai.ranking_heuristic' => DebtSimulationService::RANKING_HEURISTIC]);
+
+        $service = new StubDebtSimulationService();
+        $user    = $this->createAuthenticatedUser();
+
+        $accounts = [
+            ['account_id' => 1, 'name' => 'Loan1', 'balance' => 1000.0, 'apr' => 0.10, 'min_payment' => 0.0],
+        ];
+
+        $plans = $service->simulate((string) $user->id, '1', $accounts, 300.0, 2);
+
+        self::assertCount(2, $plans);
+
+        $fastPlan = null;
+        foreach ($plans as $plan) {
+            if ('fast_payoff' === $plan['strategy']) {
+                $fastPlan = $plan;
+                break;
+            }
+        }
+
+        self::assertNotNull($fastPlan);
+        self::assertIsArray($fastPlan);
+        self::assertFalse($fastPlan['is_optimal']);
+        self::assertSame(-6, $fastPlan['cost_of_deviation']['time_months']);
+        self::assertSame('loses 40.00 in interest savings but 6 fewer months', $fastPlan['meta']['tradeoffs']);
+        self::assertSame('less interest saved despite faster payoff', $fastPlan['meta']['ranking_reason']);
+    }
+
     public function testRankingHeuristicCanBeConfigured(): void
     {
         $strategies = [


### PR DESCRIPTION
## Summary
- update debt simulation meta messaging to describe faster but less optimal plans with a "fewer months" tradeoff and aligned ranking reasons
- add a unit test covering the faster non-optimal plan scenario to lock in the revised messaging

## Testing
- ./vendor/bin/phpunit tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cd77624f048326ad9267b8183738b3