### PR TITLE
docs: expand debt simulation heuristics overview

### DIFF
--- a/docs/ai-extension.md
+++ b/docs/ai-extension.md
@@ -7,7 +7,7 @@ Firefly III includes experimental AI-powered features that extend the core appli
 - `POST /api/v1/plaid-hook` – Receives webhooks from Plaid and stores transaction groups after verifying the request signature.
 - `GET /api/v1/goals/{goal}/projection` – Generates a Monte Carlo projection for a goal using parameters like `initial`, `mean`, `stdev`, and `years`.
 - `POST /api/v1/signals` – Accepts trading signals and forwards them to the configured broker.
-- `POST /api/v1/simulations/debt` – Evaluates debt payoff strategies using avalanche and snowball heuristics.
+- `POST /api/v1/simulations/debt` – Evaluates debt payoff strategies using avalanche, snowball, balanced, and machine-learning heuristics.
 
 ## Modules
 
@@ -21,7 +21,14 @@ Uses a Monte Carlo simulation service to estimate goal growth and returns a JSON
 Validates trading signals (`asset`, `action`, `confidence`) and relays them via the broker SDK to external trading platforms.
 
 ### Debt Simulation
-Runs heuristic strategies to generate ranked payoff plans for outstanding debts. See [Debt Simulation](debt-simulation.md) for request and response details.
+Runs heuristic strategies to generate ranked payoff plans for outstanding debts. The simulator currently includes:
+
+- **Avalanche** – Puts every extra dollar toward the debt with the highest APR. When no balances remain, the selector returns `null`, signalling the scheduler to stop allocating overpayments.
+- **Snowball** – Targets the smallest balance first to create early wins. It also yields `null` once every tracked debt is paid off so the cycle exits cleanly.
+- **Balanced** – Uses a smooth weighted round-robin algorithm to spread surplus payments proportionally across outstanding balances. If minimum payments exhaust the monthly budget or all debts reach zero, no additional allocations are made.
+- **ML** – Invokes an ONNX Runtime model to choose the next debt based on learned patterns. Whenever the model file is missing, fails to load, or scores stay below the configured threshold, it falls back to the avalanche heuristic.
+
+See the [Debt Simulation](debt-simulation.md) documentation—especially the [heuristics overview](debt-simulation.md#heuristics)—for request/response schemas and ranking details.
 
 ### Webhooks & Event Bus
 `FinanceEventService` publishes finance events over Redis channels prefixed with `ume.events.finance.` for downstream consumers.

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -146,7 +146,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
   - `rank` – Position of the plan when sorted by total interest (1 is best).
   - `is_optimal` – Indicates whether the plan is the top-ranked option.
   - `plan` – Detailed strategy output:
-    - `strategy` – Name of the heuristic applied (`avalanche`, `snowball` or `balanced`).
+    - `strategy` – Name of the heuristic applied (`avalanche`, `snowball`, `balanced`, or `ml`).
     - `schedule` – Monthly breakdown of payments, balances, interest and cash flow.
     - `recommendations` – Array of refinance suggestions derived from the input debts.
   - `metrics` – Aggregated plan results:
@@ -165,19 +165,23 @@ Simulation results are cached per user to speed up repeated requests. The cache 
 
 ## Heuristics
 
-The service supports three payoff strategies:
+The service supports four payoff strategies:
 
 ### Avalanche
 
-Prioritises accounts with the highest interest rate.
+Prioritises accounts with the highest interest rate. When every balance reaches zero the selector returns `null`, signalling that no further overpayments should be scheduled.
 
 ### Snowball
 
-Targets the smallest balance first to build momentum.
+Targets the smallest balance first to build momentum. It shares the same termination behaviour as avalanche—once all balances are cleared the strategy stops recommending additional targets.
 
 ### Balanced
 
-Distributes extra payments proportionally across outstanding debts using a smooth weighted round-robin algorithm so larger balances receive additional payments more frequently. If the monthly budget is less than the combined minimum payments, the strategy applies the minimums first and no extra funds are allocated, leaving the monthly `cash_flow` at `0`.
+Distributes extra payments proportionally across outstanding debts using a smooth weighted round-robin algorithm so larger balances receive additional payments more frequently. Minimum payments are always covered first; if they consume the entire monthly budget or no eligible balances remain, the strategy produces no extra allocations for that cycle.
+
+### Machine Learning (ml)
+
+Invokes an ONNX Runtime model to score each debt and choose the highest-ranked target. Should the configured model file be missing, fail to load, or return scores below the configured threshold, the strategy falls back to the avalanche heuristic to maintain deterministic behaviour.
 
 ## Ranking and Deviation
 


### PR DESCRIPTION
## Summary
- document all four debt payoff heuristics exposed by the AI extension
- describe how each strategy behaves and when it stops or falls back
- link to the detailed debt simulation documentation for discovery

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d2a04930ec832683d66e0c546863d2