### PR TITLE
Relax Polymarket ETL partition assertions

### DIFF
--- a/fe/data/polymarket/etl.py
+++ b/fe/data/polymarket/etl.py
@@ -329,18 +329,52 @@ def save_market(
     df.to_parquet(out_file, index=False)
 
 
-def assert_partitions(output_dir: Path, days: int = 365) -> None:
-    """Ensure output directory has partitions for the last ``days`` days."""
+def assert_partitions(
+    output_dir: Path, days: int = 365, min_coverage: float = 0.9
+) -> None:
+    """Check partition coverage over the requested window.
+
+    Instead of failing when individual days are missing, we look at the
+    overall coverage and emit a warning if it drops below ``min_coverage``.
+    """
+
+    if days <= 0:
+        return
+
     today = datetime.utcnow().date()
     missing: List[str] = []
+    populated_days = 0
+
     for i in range(days):
         day = today - timedelta(days=i)
         event_dir = output_dir / f"event_date={day.isoformat()}"
-        if not event_dir.exists() or not any(event_dir.glob("category=*")):
+        if event_dir.exists() and any(event_dir.glob("category=*")):
+            populated_days += 1
+        else:
             missing.append(day.isoformat())
-    if missing:
-        raise AssertionError(
-            "missing partitions for: " + ", ".join(sorted(missing))
+
+    coverage = populated_days / days
+    if coverage < min_coverage:
+        missing_preview = ", ".join(sorted(missing)[:5])
+        if len(missing) > 5:
+            missing_preview += ", ..."
+        logger.warning(
+            (
+                "Polymarket partition coverage %.1f%% (%s/%s days) below %.1f%% "
+                "threshold; missing %s day(s): %s"
+            ),
+            coverage * 100,
+            populated_days,
+            days,
+            min_coverage * 100,
+            len(missing),
+            missing_preview,
+        )
+    elif missing:
+        logger.debug(
+            "Polymarket partitions missing %s day(s) but coverage is %.1f%%",
+            len(missing),
+            coverage * 100,
         )
 
 

--- a/tests/fe/data/test_polymarket_etl.py
+++ b/tests/fe/data/test_polymarket_etl.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -131,14 +132,16 @@ def test_save_market_continues_with_http_errors(tmp_path, monkeypatch):
     assert record["clarification_resolution_events"] == []
 
 
-def test_assert_partitions_detects_missing_days(tmp_path):
+def test_assert_partitions_warns_when_coverage_drops(tmp_path, caplog):
     today = datetime.utcnow().date()
     (
         tmp_path / f"event_date={today.isoformat()}" / "category=test"
     ).mkdir(parents=True)
 
-    with pytest.raises(AssertionError) as exc:
+    with caplog.at_level(logging.WARNING):
         etl.assert_partitions(tmp_path, days=2)
 
-    missing_day = (today - timedelta(days=1)).isoformat()
-    assert missing_day in str(exc.value)
+    assert any(
+        record.levelno == logging.WARNING and "coverage" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- update the Polymarket ETL partition check to measure overall coverage and warn when it drops below the minimum threshold
- extend the ETL unit tests to verify the relaxed behavior when a day lacks market data

## Testing
- pytest tests/fe/data/test_polymarket_etl.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1e733c348326b382e66b5eb8a232