### PR TITLE
Guard approval gate against negative drawdown magnitudes

### DIFF
--- a/fe/signoff/gate.py
+++ b/fe/signoff/gate.py
@@ -66,7 +66,12 @@ def approve(
     sample = strategy_report.get("sample_size", 0)
     mdd = strategy_report.get("max_drawdown", float("inf"))
     pval = strategy_report.get("p_value", 1.0)
-    return sample >= sample_threshold and mdd <= mdd_threshold and pval < alpha_threshold
+
+    return (
+        sample >= sample_threshold
+        and abs(mdd) <= mdd_threshold
+        and pval < alpha_threshold
+    )
 
 
 __all__ = ["approve", "MIN_SAMPLE", "MAX_MDD", "ALPHA"]

--- a/tests/fe/signoff/test_gate.py
+++ b/tests/fe/signoff/test_gate.py
@@ -36,3 +36,19 @@ def test_approve_with_strict_config():
     cfg = CONFIG_DIR / "strict.json"
     report = {"sample_size": MIN_SAMPLE, "max_drawdown": MAX_MDD, "p_value": ALPHA - 0.01}
     assert not approve(report, config_path=cfg)
+
+
+def test_approve_handles_negative_drawdown():
+    failing_report = {
+        "sample_size": MIN_SAMPLE,
+        "max_drawdown": -0.35,
+        "p_value": ALPHA - 0.01,
+    }
+    passing_report = {
+        "sample_size": MIN_SAMPLE,
+        "max_drawdown": -0.1,
+        "p_value": ALPHA - 0.01,
+    }
+
+    assert not approve(failing_report)
+    assert approve(passing_report)


### PR DESCRIPTION
## Summary
- ensure the approval gate checks the magnitude of max drawdown before accepting a report
- add coverage to verify negative drawdowns that exceed the threshold are rejected while compliant ones pass

## Testing
- pytest tests/fe/signoff -q

------
https://chatgpt.com/codex/tasks/task_e_68dd1e726b90832696fbbfdca9b7214c