### PR TITLE
Clamp maker quote width and add regression test

### DIFF
--- a/fe/strategies/maker.py
+++ b/fe/strategies/maker.py
@@ -40,7 +40,9 @@ def make_quote(
     """
 
     mid = 0.5 * (yes + no)
-    width = spread * (1 - liq_weight * liquidity)
+    raw_width = spread * (1 - liq_weight * liquidity)
+    min_width = 0.0
+    width = max(raw_width, min_width)
     adjustment = skew_weight * skew * width
 
     bid = max(0.0, mid - width / 2 - adjustment)

--- a/tests/fe/strategies/test_maker.py
+++ b/tests/fe/strategies/test_maker.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from fe.strategies.maker import make_quote
+
+
+def test_extreme_liquidity_quote_is_not_inverted():
+    quote = make_quote(
+        yes=0.4,
+        no=0.6,
+        liquidity=1e6,
+        skew=0.0,
+        spread=0.02,
+        liq_weight=0.5,
+        skew_weight=0.5,
+    )
+
+    assert quote.bid <= quote.ask
+    assert 0.0 <= quote.bid <= 1.0
+    assert 0.0 <= quote.ask <= 1.0


### PR DESCRIPTION
## Summary
- clamp maker quote widths to a non-negative minimum before applying skew adjustments
- add a regression test ensuring quotes remain ordered under extreme liquidity

## Testing
- pytest tests/fe/strategies *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68dd20d71c288326ac37aeb583f55edb