### PR TITLE
Ensure polymarket_alpha build selects newest wheel

### DIFF
--- a/fe/export/build.py
+++ b/fe/export/build.py
@@ -97,8 +97,15 @@ description = \"Selected strategy implementations for Polymarket Alpha\"
             cwd=tmpdir,
         )
 
-    # Rename generated wheel to expected filename
-    wheel = next(dist_dir.glob("polymarket_alpha-*.whl"))
+    # Rename the newest generated wheel to the expected filename
+    wheels = sorted(
+        dist_dir.glob("polymarket_alpha-*.whl"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    if not wheels:
+        raise FileNotFoundError("No polymarket_alpha wheel found in dist directory")
+    wheel = wheels[0]
     target = dist_dir / f"polymarket_alpha_{version}.whl"
     wheel.rename(target)
     return target

--- a/tests/export/test_build.py
+++ b/tests/export/test_build.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -63,5 +65,41 @@ def test_build_wheel_gate_failure(monkeypatch):
         with pytest.raises(SystemExit, match="maker"):
             build.build_wheel("0.0.0", ["maker"])
         assert not dist_dir.exists() or not any(dist_dir.glob("*.whl"))
+    finally:
+        _cleanup([report_path, reports_dir, dist_dir])
+
+
+def test_build_wheel_prefers_newest_wheel(monkeypatch):
+    root = Path(__file__).resolve().parents[2]
+    reports_dir = root / "reports"
+    dist_dir = root / "dist"
+    reports_dir.mkdir(exist_ok=True)
+    dist_dir.mkdir(exist_ok=True)
+
+    report = {"sample_size": 100, "max_drawdown": 0.1, "p_value": 0.01}
+    report_path = reports_dir / "maker.json"
+    report_path.write_text(json.dumps(report))
+
+    monkeypatch.setattr(build, "approve", lambda rep: True)
+
+    old_wheel = dist_dir / "polymarket_alpha-legacy-py3-none-any.whl"
+    old_wheel.write_text("old wheel")
+    past_time = time.time() - 100
+    os.utime(old_wheel, (past_time, past_time))
+
+    def fake_check_call(cmd, cwd):
+        (dist_dir / "polymarket_alpha-0.0.0-py3-none-any.whl").write_text(
+            "new wheel"
+        )
+
+    monkeypatch.setattr(build.subprocess, "check_call", fake_check_call)
+
+    try:
+        wheel = build.build_wheel("0.0.0", ["maker"])
+        target = dist_dir / "polymarket_alpha_0.0.0.whl"
+        assert wheel == target
+        assert target.read_text() == "new wheel"
+        assert old_wheel.exists()
+        assert old_wheel.read_text() == "old wheel"
     finally:
         _cleanup([report_path, reports_dir, dist_dir])


### PR DESCRIPTION
## Summary
- ensure the build script renames the most recently built polymarket_alpha wheel
- add regression coverage to guard against older wheels in dist/ influencing the rename

## Testing
- pytest tests/export/test_build.py
- python -m compileall fe/export/build.py tests/export/test_build.py

------
https://chatgpt.com/codex/tasks/task_e_68de8ba0a4848326b713c1aab9a3c2fe