### PR TITLE
Update wheel export test to load strategy from wheel

### DIFF
--- a/tests/export/test_wheel.py
+++ b/tests/export/test_wheel.py
@@ -4,8 +4,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 
 def test_wheel_install_and_strategy_load(tmp_path: Path) -> None:
@@ -34,7 +35,12 @@ def test_wheel_install_and_strategy_load(tmp_path: Path) -> None:
     )
 
     sys.path.insert(0, str(target))
-    from fe.strategies.deadline_no import DeadlineNoStrategy
+    from polymarket_alpha.strategies.deadline_no import DeadlineNoStrategy
+
+    assert (
+        DeadlineNoStrategy.__module__
+        == "polymarket_alpha.strategies.deadline_no"
+    ), "Strategy should be loaded from installed wheel"
 
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- import the deadline-no strategy from the installed polymarket_alpha wheel
- ensure the test verifies the strategy comes from the wheel and skip if pandas is unavailable

## Testing
- pytest tests/export/test_wheel.py

------
https://chatgpt.com/codex/tasks/task_e_68de8ba1a2dc8326b9bada04be31b9bc