### PR TITLE
Raise error when Polymarket partitions incomplete

### DIFF
--- a/fe/data/polymarket/etl.py
+++ b/fe/data/polymarket/etl.py
@@ -89,7 +89,12 @@ def _retry_operation(
     logger.error("Giving up on %s after %s attempts", description, attempts)
     return None
 
+
 logger = logging.getLogger(__name__)
+
+
+class PartitionCoverageError(RuntimeError):
+    """Raised when partition coverage falls below the minimum threshold."""
 
 
 def _get(url: str, params: Dict[str, Any] | None = None) -> Any | None:
@@ -341,7 +346,8 @@ def assert_partitions(
     """Check partition coverage over the requested window.
 
     Instead of failing when individual days are missing, we look at the
-    overall coverage and emit a warning if it drops below ``min_coverage``.
+    overall coverage and raise :class:`PartitionCoverageError` if it drops
+    below ``min_coverage``.
     """
 
     if days <= 0:
@@ -364,17 +370,19 @@ def assert_partitions(
         missing_preview = ", ".join(sorted(missing)[:5])
         if len(missing) > 5:
             missing_preview += ", ..."
-        logger.warning(
+        raise PartitionCoverageError(
             (
                 "Polymarket partition coverage %.1f%% (%s/%s days) below %.1f%% "
                 "threshold; missing %s day(s): %s"
-            ),
-            coverage * 100,
-            populated_days,
-            days,
-            min_coverage * 100,
-            len(missing),
-            missing_preview,
+            )
+            % (
+                coverage * 100,
+                populated_days,
+                days,
+                min_coverage * 100,
+                len(missing),
+                missing_preview,
+            )
         )
     elif missing:
         logger.debug(
@@ -406,7 +414,11 @@ def cli() -> None:
         help="Number of days of resolved markets to process",
     )
     args = parser.parse_args()
-    main(args.output_dir, args.days)
+    try:
+        main(args.output_dir, args.days)
+    except PartitionCoverageError as exc:
+        logger.error("%s", exc)
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/tests/fe/data/test_polymarket_etl.py
+++ b/tests/fe/data/test_polymarket_etl.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import types
 from datetime import datetime, timedelta
@@ -259,16 +258,38 @@ def test_save_market_continues_with_http_errors(tmp_path, monkeypatch):
     assert record["clarification_resolution_events"] == []
 
 
-def test_assert_partitions_warns_when_coverage_drops(tmp_path, caplog):
+def test_assert_partitions_succeeds_with_sufficient_coverage(tmp_path):
+    today = datetime.utcnow().date()
+    for offset in range(2):
+        day = today - timedelta(days=offset)
+        (
+            tmp_path / f"event_date={day.isoformat()}" / "category=test"
+        ).mkdir(parents=True)
+
+    etl.assert_partitions(tmp_path, days=2)
+
+
+def test_assert_partitions_raises_when_coverage_drops(tmp_path):
     today = datetime.utcnow().date()
     (
         tmp_path / f"event_date={today.isoformat()}" / "category=test"
     ).mkdir(parents=True)
 
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(etl.PartitionCoverageError) as excinfo:
         etl.assert_partitions(tmp_path, days=2)
 
-    assert any(
-        record.levelno == logging.WARNING and "coverage" in record.getMessage()
-        for record in caplog.records
-    )
+    assert "coverage" in str(excinfo.value)
+
+
+def test_cli_exits_non_zero_on_partition_failure(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["polymarket-etl"])
+
+    def failing_main(*args, **kwargs):
+        raise etl.PartitionCoverageError("boom")
+
+    monkeypatch.setattr(etl, "main", failing_main)
+
+    with pytest.raises(SystemExit) as excinfo:
+        etl.cli()
+
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## Summary
- raise a dedicated `PartitionCoverageError` when partition coverage falls below the minimum threshold
- update the CLI to exit with status 1 on coverage failures and extend tests for success/failure and CLI behavior

## Testing
- pytest tests/fe/data/test_polymarket_etl.py
- pytest tests/fe/test_polymarket_etl.py
- flake8 --max-line-length=120 fe/data/polymarket/etl.py tests/fe/data/test_polymarket_etl.py

------
https://chatgpt.com/codex/tasks/task_e_68de95aa37548326bed143724434e38c