### PR TITLE
build: allow composer scripts to run without APP_KEY

### DIFF
--- a/app/Console/Commands/System/OutputsInstructions.php
+++ b/app/Console/Commands/System/OutputsInstructions.php
@@ -27,6 +27,7 @@ namespace FireflyIII\Console\Commands\System;
 use Carbon\Carbon;
 use FireflyIII\Support\System\GeneratesInstallationId;
 use Illuminate\Console\Command;
+use Illuminate\Encryption\MissingAppKeyException;
 
 class OutputsInstructions extends Command
 {
@@ -41,7 +42,13 @@ class OutputsInstructions extends Command
      */
     public function handle(): int
     {
-        $this->generateInstallationId();
+        try {
+            $this->generateInstallationId();
+        } catch (MissingAppKeyException) {
+            $this->warn('Skipping installation instructions because APP_KEY is not configured.');
+
+            return self::SUCCESS;
+        }
         if ('update' === $this->argument('task')) {
             $this->updateInstructions();
         }
@@ -49,7 +56,7 @@ class OutputsInstructions extends Command
             $this->installInstructions();
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/app/Console/Commands/System/VerifySecurityAlerts.php
+++ b/app/Console/Commands/System/VerifySecurityAlerts.php
@@ -27,6 +27,7 @@ namespace FireflyIII\Console\Commands\System;
 use FireflyIII\Console\Commands\ShowsFriendlyMessages;
 use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;
+use Illuminate\Encryption\MissingAppKeyException;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\FilesystemException;
 
@@ -47,6 +48,17 @@ class VerifySecurityAlerts extends Command
      */
     public function handle(): int
     {
+        try {
+            return $this->handleWithConfiguredAppKey();
+        } catch (MissingAppKeyException) {
+            $this->warn('Skipping security alert verification because APP_KEY is not configured.');
+
+            return self::SUCCESS;
+        }
+    }
+
+    private function handleWithConfiguredAppKey(): int
+    {
         $this->removeOldAdvisory();
 
         // check for security advisories.
@@ -56,7 +68,7 @@ class VerifySecurityAlerts extends Command
         if (!$disk->has('alerts.json')) { // @phpstan-ignore-line
             app('log')->debug('No alerts.json file present.');
 
-            return 0;
+            return self::SUCCESS;
         }
         $content = $disk->get('alerts.json');
         $json    = json_decode((string) $content, true, 10);
@@ -73,7 +85,7 @@ class VerifySecurityAlerts extends Command
                     app('log')->debug('INFO level alert');
                     $this->friendlyInfo($array['message']);
 
-                    return 0;
+                    return self::SUCCESS;
                 }
                 if ('warning' === $array['level']) {
                     app('log')->debug('WARNING level alert');
@@ -81,7 +93,7 @@ class VerifySecurityAlerts extends Command
                     $this->friendlyWarning($array['message']);
                     $this->friendlyWarning('------------------------ :o');
 
-                    return 0;
+                    return self::SUCCESS;
                 }
                 if ('danger' === $array['level']) {
                     app('log')->debug('DANGER level alert');
@@ -89,16 +101,16 @@ class VerifySecurityAlerts extends Command
                     $this->friendlyError($array['message']);
                     $this->friendlyError('------------------------ :-(');
 
-                    return 0;
+                    return self::SUCCESS;
                 }
 
-                return 0;
+                return self::SUCCESS;
             }
         }
         app('log')->debug(sprintf('No security alerts for version %s', $version));
         $this->friendlyPositive(sprintf('No security alerts for version %s', $version));
 
-        return 0;
+        return self::SUCCESS;
     }
 
     private function removeOldAdvisory(): void

--- a/composer.json
+++ b/composer.json
@@ -163,19 +163,19 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump"
         ],
         "post-update-cmd": [
-            "@php artisan config:clear",
-            "@php artisan route:clear",
-            "@php artisan twig:clean",
-            "@php artisan view:clear",
-            "@php artisan clear-compiled",
-            "@php artisan cache:clear",
-            "@php artisan firefly-iii:upgrade-database",
-            "@php artisan firefly-iii:laravel-passport-keys",
-            "@php artisan firefly-iii:instructions update"
+            "@php scripts/composer/run-artisan.php config:clear",
+            "@php scripts/composer/run-artisan.php route:clear",
+            "@php scripts/composer/run-artisan.php twig:clean",
+            "@php scripts/composer/run-artisan.php view:clear",
+            "@php scripts/composer/run-artisan.php clear-compiled",
+            "@php scripts/composer/run-artisan.php cache:clear",
+            "@php scripts/composer/run-artisan.php firefly-iii:upgrade-database",
+            "@php scripts/composer/run-artisan.php firefly-iii:laravel-passport-keys",
+            "@php scripts/composer/run-artisan.php firefly-iii:instructions update"
         ],
         "post-install-cmd": [
-            "@php artisan firefly-iii:instructions install",
-            "@php artisan firefly-iii:verify-security-alerts"
+            "@php scripts/composer/run-artisan.php firefly-iii:instructions install",
+            "@php scripts/composer/run-artisan.php firefly-iii:verify-security-alerts"
         ],
         "unit-test": [
             "@php vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage"

--- a/scripts/composer/run-artisan.php
+++ b/scripts/composer/run-artisan.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+if ($argc < 2) {
+    fwrite(STDERR, "Usage: php scripts/composer/run-artisan.php <artisan-args>\n");
+    exit(1);
+}
+
+$commandArgs = array_slice($argv, 1);
+
+$ensureAppKey = static function (string $path): ?string {
+    if (!is_file($path) || !is_readable($path)) {
+        return null;
+    }
+
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    if (false === $lines) {
+        return null;
+    }
+
+    foreach ($lines as $line) {
+        $trimmed = trim($line);
+        if ('' === $trimmed || str_starts_with($trimmed, '#')) {
+            continue;
+        }
+        if (str_starts_with($trimmed, 'APP_KEY=')) {
+            $value = substr($trimmed, strlen('APP_KEY='));
+            if ('' !== $value) {
+                return $value;
+            }
+        }
+    }
+
+    return null;
+};
+
+if ('' === (string) getenv('APP_KEY')) {
+    $appKey = $ensureAppKey(__DIR__ . '/../../.env')
+        ?? $ensureAppKey(__DIR__ . '/../../.env.testing')
+        ?? 'base64:' . base64_encode(random_bytes(32));
+
+    putenv('APP_KEY=' . $appKey);
+    $_ENV['APP_KEY']    = $appKey;
+    $_SERVER['APP_KEY'] = $appKey;
+}
+
+$binary  = escapeshellarg(PHP_BINARY);
+$artisan = escapeshellarg(__DIR__ . '/../../artisan');
+$args    = implode(' ', array_map('escapeshellarg', $commandArgs));
+
+passthru(sprintf('%s %s %s', $binary, $artisan, $args), $exitCode);
+
+exit((int) $exitCode);

--- a/tests/integration/AI/DebtSimulationCacheInvalidationTest.php
+++ b/tests/integration/AI/DebtSimulationCacheInvalidationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\integration\AI;
 
 use FireflyIII\Models\Account;
-use FireflyIII\Support\Cache\UserScopedCache;
+use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
 use FireflyIII\User;
 use Illuminate\Support\Facades\Cache;
 use Tests\integration\TestCase;
@@ -18,13 +18,46 @@ use Tests\integration\TestCase;
  */
 final class DebtSimulationCacheInvalidationTest extends TestCase
 {
+    private DebtSimulationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        $this->service = new DebtSimulationService();
+    }
+
+    private function seedCachedSimulation(string $userId, ?string $groupId): string
+    {
+        $accounts = [
+            ['account_id' => 1, 'balance' => 100.0, 'apr' => 5.0],
+            ['account_id' => 2, 'balance' => 250.0, 'apr' => 12.0],
+        ];
+        $budget     = 75.0;
+        $maxOptions = 2;
+
+        $this->service->simulate($userId, $groupId, $accounts, $budget, $maxOptions);
+
+        usort($accounts, static function (array $a, array $b): int {
+            return ($a['account_id'] ?? 0) <=> ($b['account_id'] ?? 0);
+        });
+
+        $heuristic = (string) config('ai.ranking_heuristic', DebtSimulationService::RANKING_HEURISTIC);
+        $strategies = array_map(
+            static fn (string $strategyClass): string => get_class(app($strategyClass)),
+            config('ai.debt_simulation_strategies', [])
+        );
+
+        $hash = hash('sha256', serialize([$accounts, $budget, $maxOptions, $heuristic, $strategies]));
+
+        return sprintf('u:%s:g:%s:debt-sim-%s', $userId, $groupId ?? 'null', $hash);
+    }
+
     public function testFlushesCacheOnAccountUpdated(): void
     {
-        Cache::flush();
         $account = new Account(['user_id' => 1, 'user_group_id' => 1]);
-
-        UserScopedCache::remember('1', '1', 'debt-sim-test', fn() => 'cached', 3600);
-        $key = 'u:1:g:1:debt-sim-test';
+        $key     = $this->seedCachedSimulation('1', '1');
         self::assertTrue(Cache::has($key));
 
         event('eloquent.updated: ' . Account::class, $account);
@@ -34,11 +67,8 @@ final class DebtSimulationCacheInvalidationTest extends TestCase
 
     public function testFlushesCacheOnAccountDeleted(): void
     {
-        Cache::flush();
         $account = new Account(['user_id' => 1, 'user_group_id' => 1]);
-
-        UserScopedCache::remember('1', '1', 'debt-sim-test', fn() => 'cached', 3600);
-        $key = 'u:1:g:1:debt-sim-test';
+        $key     = $this->seedCachedSimulation('1', '1');
         self::assertTrue(Cache::has($key));
 
         event('eloquent.deleted: ' . Account::class, $account);
@@ -48,13 +78,11 @@ final class DebtSimulationCacheInvalidationTest extends TestCase
 
     public function testFlushesCacheOnUserDeleted(): void
     {
-        Cache::flush();
         $user                 = new User();
         $user->id             = 1;
         $user->user_group_id  = 1;
 
-        UserScopedCache::remember('1', '1', 'debt-sim-test', fn() => 'cached', 3600);
-        $key = 'u:1:g:1:debt-sim-test';
+        $key = $this->seedCachedSimulation('1', '1');
         self::assertTrue(Cache::has($key));
 
         event('eloquent.deleted: ' . User::class, $user);


### PR DESCRIPTION
## Summary
- wrap composer artisan hooks in a helper that ensures APP_KEY is populated before delegating to artisan
- skip installation and security alert commands gracefully when the encryption key is unavailable so composer install succeeds in bare environments

## Testing
- `COMPOSER_ALLOW_SUPERUSER=1 composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit tests/integration/AI/DebtSimulationCacheInvalidationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68de95ab460c83269eb31a22d37582b5