### PR TITLE
Fix cash flow semantics in debt simulation outputs

### DIFF
--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -377,9 +377,14 @@ class DebtSimulationService
                 unset($target);
             }
 
-            $totalPayment      = array_sum($paymentPlan);
-            $totalInterest    += $interestThisMonth;
-            $cashFlowTimeline[] = ['month' => $month, 'cash_flow' => $remainingBudget];
+            $totalPayment    = array_sum($paymentPlan);
+            $unusedBudget    = max($remainingBudget, 0.0);
+            $totalInterest  += $interestThisMonth;
+            $cashFlowTimeline[] = [
+                'month'         => $month,
+                'cash_flow'     => $totalPayment,
+                'unused_budget' => $unusedBudget,
+            ];
 
             $balanceSnapshot = [];
             $balanceAfter    = 0.0;
@@ -390,12 +395,13 @@ class DebtSimulationService
             }
 
             $schedule[] = [
-                'month'     => $month,
-                'payments'  => $paymentPlan,
-                'balances'  => $balanceSnapshot,
-                'interest'  => $interestThisMonth,
-                'payment'   => $totalPayment,
-                'cash_flow' => $remainingBudget,
+                'month'         => $month,
+                'payments'      => $paymentPlan,
+                'balances'      => $balanceSnapshot,
+                'interest'      => $interestThisMonth,
+                'payment'       => $totalPayment,
+                'cash_flow'     => $totalPayment,
+                'unused_budget' => $unusedBudget,
             ];
 
             if ($balanceAfter > $balanceBefore) {

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -73,7 +73,8 @@ Simulation results are cached per user to speed up repeated requests. The cache 
 
             "interest": 60,
             "payment": 500,
-            "cash_flow": 0
+            "cash_flow": 500,
+            "unused_budget": 0
           }
 
         ],
@@ -86,7 +87,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
         "time_to_payoff_months": 34,
         "total_interest_paid": 516.09,
         "monthly_cash_flow": [
-          {"month": 1, "cash_flow": 0}
+          {"month": 1, "cash_flow": 500, "unused_budget": 0}
         ]
       },
       "cost_of_deviation": {
@@ -111,7 +112,8 @@ Simulation results are cached per user to speed up repeated requests. The cache 
 
             "interest": 57.19,
             "payment": 500,
-            "cash_flow": 0
+            "cash_flow": 500,
+            "unused_budget": 0
           }
 
         ],
@@ -124,7 +126,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
         "time_to_payoff_months": 36,
         "total_interest_paid": 577.97,
         "monthly_cash_flow": [
-          {"month": 1, "cash_flow": 0}
+          {"month": 1, "cash_flow": 500, "unused_budget": 0}
         ]
       },
       "cost_of_deviation": {
@@ -155,7 +157,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
     - `interest_saved` – Interest saved compared to the optimal plan (negative values indicate extra interest).
     - `time_to_payoff_months` – Number of months to clear all debts.
     - `total_interest_paid` – Total interest paid over the lifetime of the plan.
-    - `monthly_cash_flow` – Remaining budget for each month.
+    - `monthly_cash_flow` – Actual cash payments (and unused budget) for each month.
   - `cost_of_deviation` – Extra cost versus the optimal plan:
     - `currency` – Additional interest compared to the optimal plan.
     - `time_months` – Additional duration compared to the optimal plan in months.

--- a/tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceBudgetTest.php
@@ -35,7 +35,15 @@ final class DebtSimulationServiceBudgetTest extends TestCase
         $plans = $service->simulate($userId, $groupId, $accounts, 50.0, 1);
 
         foreach ($plans[0]['schedule'] as $month) {
-            self::assertGreaterThanOrEqual(0.0, $month['cash_flow']);
+            self::assertSame($month['payment'], $month['cash_flow']);
+            self::assertArrayHasKey('unused_budget', $month);
+            self::assertGreaterThanOrEqual(0.0, $month['unused_budget']);
+        }
+
+        foreach ($plans[0]['monthly_cash_flow'] as $index => $month) {
+            self::assertSame($plans[0]['schedule'][$index]['cash_flow'], $month['cash_flow']);
+            self::assertArrayHasKey('unused_budget', $month);
+            self::assertGreaterThanOrEqual(0.0, $month['unused_budget']);
         }
     }
 


### PR DESCRIPTION
## Summary
- update debt simulation schedules and monthly timeline to report true cash outflows while tracking unused budget separately
- refresh documentation and unit coverage to match the new cash-flow semantics

## Testing
- ./vendor/bin/phpunit tests/unit/Modules/AI

------
https://chatgpt.com/codex/tasks/task_e_68dfed9731f88326b5846ac55a62c5db