### PR TITLE
Require auth for debt simulation API

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1008,5 +1008,9 @@ Route::get('v1/goals/{id}/projection', ProjectionController::class)
     ->name('api.v1.goals.projection');
 Route::get('v1/goals/{goal}/projection', ProjectionController::class)
     ->name('api.v1.goal-projection');
-Route::post('v1/simulations/debt', DebtController::class)
-    ->name('api.v1.simulations.debt');
+Route::middleware(['auth:api,sanctum', 'bindings'])->group(
+    static function (): void {
+        Route::post('v1/simulations/debt', DebtController::class)
+            ->name('api.v1.simulations.debt');
+    }
+);

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -10,8 +10,8 @@ use FireflyIII\Models\Account;
 use FireflyIII\Models\AccountType;
 use FireflyIII\User;
 use Illuminate\Support\Facades\Cache;
-use FireflyIII\Http\Middleware\Authenticate;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Laravel\Sanctum\Sanctum;
 use FireflyIII\Http\Middleware\OpaMiddleware;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Schema;
@@ -22,14 +22,18 @@ use function Safe\putenv;
 
 final class DebtSimulationApiTest extends IntegrationTestCase
 {
+    public function testUnauthenticatedRequestsAreRejected(): void
+    {
+        $this->postJson('/api/v1/simulations/debt', [])->assertUnauthorized();
+    }
+
     public function testUserIsolationAndCaching(): void
     {
         Cache::setDefaultDriver('file');
         putenv('CACHE_DRIVER=file');
         Cache::flush();
-        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
-        config(['auth.defaults.guard' => 'web']);
-
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
+        $this->withoutMiddleware([EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
         $budget     = 50.0;
         $maxOptions = 2;
 
@@ -70,7 +74,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $account2->uuid = (string) Str::uuid();
         $account2->save();
         $account2->refresh();
-        $this->be($user1);
+        Sanctum::actingAs($user1);
 
         $accounts1 = [
             [
@@ -183,7 +187,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $account4->uuid = (string) Str::uuid();
         $account4->save();
         $account4->refresh();
-        $this->be($user2);
+        Sanctum::actingAs($user2);
 
         $accounts2 = [
             [
@@ -218,9 +222,8 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         Cache::setDefaultDriver('file');
         putenv('CACHE_DRIVER=file');
         Cache::flush();
-        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
-        config(['auth.defaults.guard' => 'web']);
-
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
+        $this->withoutMiddleware([EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
         if (!Schema::hasColumn('users', 'uuid')) {
             Schema::table('users', static function (Blueprint $table): void {
                 $table->uuid('uuid')->nullable();
@@ -258,7 +261,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $accountB->uuid = (string) Str::uuid();
         $accountB->save();
         $accountB->refresh();
-        $this->be($user);
+        Sanctum::actingAs($user);
 
         $payload = [
             'user_id'        => $user->uuid,
@@ -309,9 +312,8 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         Cache::setDefaultDriver('file');
         putenv('CACHE_DRIVER=file');
         Cache::flush();
-        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
-        config(['auth.defaults.guard' => 'web']);
-
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
+        $this->withoutMiddleware([EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
         if (!Schema::hasColumn('users', 'uuid')) {
             Schema::table('users', static function (Blueprint $table): void {
                 $table->uuid('uuid')->nullable();
@@ -339,7 +341,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         $account->uuid = (string) Str::uuid();
         $account->save();
         $account->refresh();
-        $this->be($user);
+        Sanctum::actingAs($user);
 
         $strategies   = config('ai.debt_simulation_strategies', []);
         $strategyCount = is_countable($strategies) ? count($strategies) : 0;
@@ -399,13 +401,12 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         Cache::setDefaultDriver('file');
         putenv('CACHE_DRIVER=file');
         Cache::flush();
-        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
-        config(['auth.defaults.guard' => 'web']);
-
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
+        $this->withoutMiddleware([EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
         $user1 = User::create(['email' => 'user1@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user1);
         $user1->refresh();
-        $this->be($user1);
+        Sanctum::actingAs($user1);
 
         $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user2);
@@ -445,13 +446,12 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         Cache::setDefaultDriver('file');
         putenv('CACHE_DRIVER=file');
         Cache::flush();
-        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
-        config(['auth.defaults.guard' => 'web']);
-
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
+        $this->withoutMiddleware([EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
         $user1 = User::create(['email' => 'user1@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user1);
         $user1->refresh();
-        $this->be($user1);
+        Sanctum::actingAs($user1);
 
         $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user2);

--- a/tests/api/v1/Simulations/DebtSimulationTest.php
+++ b/tests/api/v1/Simulations/DebtSimulationTest.php
@@ -6,8 +6,8 @@ namespace Tests\api\v1\Simulations;
 
 use FireflyIII\Console\Commands\Correction\CreatesGroupMemberships;
 use FireflyIII\Enums\AccountTypeEnum;
-use FireflyIII\Http\Middleware\Authenticate;
 use FireflyIII\Http\Middleware\OpaMiddleware;
+use Laravel\Sanctum\Sanctum;
 use FireflyIII\Models\Account;
 use FireflyIII\Models\AccountType;
 use FireflyIII\User;
@@ -45,8 +45,8 @@ final class DebtSimulationTest extends TestCase
         Cache::setDefaultDriver('file');
         putenv('CACHE_DRIVER=file');
         Cache::flush();
-        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
-        config(['auth.defaults.guard' => 'web']);
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
+        $this->withoutMiddleware([EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
 
         $this->ensureUuidColumns();
 
@@ -58,7 +58,7 @@ final class DebtSimulationTest extends TestCase
             $user1->save();
             $user1->refresh();
         }
-        $this->be($user1);
+        Sanctum::actingAs($user1);
 
         $user2 = User::create(['email' => 'user2@example.com', 'password' => 'secret']);
         CreatesGroupMemberships::createGroupMembership($user2);
@@ -107,8 +107,8 @@ final class DebtSimulationTest extends TestCase
         Cache::setDefaultDriver('file');
         putenv('CACHE_DRIVER=file');
         Cache::flush();
-        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
-        config(['auth.defaults.guard' => 'web']);
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
+        $this->withoutMiddleware([EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
 
         $this->ensureUuidColumns();
 
@@ -123,7 +123,7 @@ final class DebtSimulationTest extends TestCase
             $user->save();
             $user->refresh();
         }
-        $this->be($user);
+        Sanctum::actingAs($user);
 
         $type = AccountType::where('type', AccountTypeEnum::DEBT->value)->first();
         $a1   = Account::create([
@@ -226,8 +226,8 @@ final class DebtSimulationTest extends TestCase
         Cache::setDefaultDriver('file');
         putenv('CACHE_DRIVER=file');
         Cache::flush();
-        $this->withoutMiddleware([Authenticate::class, 'auth:api', 'auth:api,sanctum', EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
-        config(['auth.defaults.guard' => 'web']);
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
+        $this->withoutMiddleware([EnsureFrontendRequestsAreStateful::class, OpaMiddleware::class]);
 
         $this->ensureUuidColumns();
 
@@ -239,7 +239,7 @@ final class DebtSimulationTest extends TestCase
             $user->save();
             $user->refresh();
         }
-        $this->be($user);
+        Sanctum::actingAs($user);
 
         $type = AccountType::where('type', AccountTypeEnum::DEBT->value)->first();
         $a1   = Account::create([

--- a/tests/integration/AI/DebtSimulationEndpointTest.php
+++ b/tests/integration/AI/DebtSimulationEndpointTest.php
@@ -6,7 +6,6 @@ namespace Tests\integration\AI;
 
 use FireflyIII\Console\Commands\Correction\CreatesGroupMemberships;
 use FireflyIII\Enums\AccountTypeEnum;
-use FireflyIII\Http\Middleware\Authenticate;
 use FireflyIII\Http\Middleware\OpaMiddleware;
 use FireflyIII\Models\Account;
 use FireflyIII\Models\AccountType;
@@ -17,6 +16,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Laravel\Sanctum\Sanctum;
 use Tests\integration\TestCase;
 use Override;
 
@@ -42,12 +42,9 @@ final class DebtSimulationEndpointTest extends TestCase
         Cache::setDefaultDriver('array');
         Cache::flush();
 
-        config(['auth.defaults.guard' => 'web']);
+        config(['auth.guards.api' => ['driver' => 'token', 'provider' => 'users']]);
 
         $this->withoutMiddleware([
-            Authenticate::class,
-            'auth:api',
-            'auth:api,sanctum',
             EnsureFrontendRequestsAreStateful::class,
             OpaMiddleware::class,
         ]);
@@ -65,8 +62,7 @@ final class DebtSimulationEndpointTest extends TestCase
             $this->user->refresh();
         }
 
-        $this->be($this->user);
-        auth()->setUser($this->user);
+        Sanctum::actingAs($this->user);
 
         $this->debtType = AccountType::where('type', AccountTypeEnum::DEBT->value)->firstOrFail();
     }


### PR DESCRIPTION
## Summary
- secure the debt simulation endpoint with the shared auth middleware stack
- update debt simulation tests to exercise authenticated and unauthenticated flows via Sanctum

## Testing
- ./vendor/bin/phpunit --filter DebtSimulation

------
https://chatgpt.com/codex/tasks/task_e_68e91a2a75888326b535af902260d1bf