### PR TITLE
Handle user primary group cache invalidation

### DIFF
--- a/app/Listeners/FlushDebtSimulationCache.php
+++ b/app/Listeners/FlushDebtSimulationCache.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace FireflyIII\Listeners;
 
 use FireflyIII\Models\Account;
+use FireflyIII\Models\GroupMembership;
 use FireflyIII\Support\Cache\UserScopedCache;
 use FireflyIII\User;
+use Illuminate\Support\Collection;
 
 /**
  * Flushes the user scoped cache for debt simulations when an account or user changes.
@@ -15,9 +17,49 @@ class FlushDebtSimulationCache
 {
     public function handle(Account|User $model): void
     {
-        $userId  = $model instanceof Account ? (string) $model->user_id : (string) $model->id;
-        $groupId = $model->user_group_id === null ? null : (string) $model->user_group_id;
+        if ($model instanceof Account) {
+            $userId  = (string) $model->user_id;
+            $groupId = $model->user_group_id === null ? null : (string) $model->user_group_id;
 
-        UserScopedCache::flush($userId, $groupId);
+            UserScopedCache::flush($userId, $groupId);
+
+            return;
+        }
+
+        $userId = (string) $model->id;
+
+        // Always flush the default scope.
+        UserScopedCache::flush($userId, null);
+
+        $groupIds = $this->getMemberships($model)
+            ->pluck('user_group_id')
+            ->filter(static fn ($groupId): bool => null !== $groupId)
+            ->map(static fn ($groupId): string => (string) $groupId);
+
+        if (null !== $model->user_group_id) {
+            $groupIds->push((string) $model->user_group_id);
+        }
+
+        $groupIds
+            ->unique()
+            ->each(static function (string $groupId) use ($userId): void {
+                UserScopedCache::flush($userId, $groupId);
+            });
+    }
+
+    /**
+     * @return Collection<int, GroupMembership>
+     */
+    private function getMemberships(User $user): Collection
+    {
+        if ($user->relationLoaded('groupMemberships')) {
+            return $user->groupMemberships;
+        }
+
+        if (!$user->exists) {
+            return collect();
+        }
+
+        return $user->groupMemberships()->get();
     }
 }

--- a/app/Listeners/UserGroupMembershipChanged.php
+++ b/app/Listeners/UserGroupMembershipChanged.php
@@ -6,6 +6,7 @@ namespace FireflyIII\Listeners;
 
 use FireflyIII\Models\GroupMembership;
 use FireflyIII\Support\Cache\UserScopedCache;
+use FireflyIII\User;
 
 class UserGroupMembershipChanged
 {
@@ -33,6 +34,34 @@ class UserGroupMembershipChanged
             return;
         }
 
-        UserScopedCache::flush((string) $userId, null === $groupId ? null : (string) $groupId);
+        $userIdString = (string) $userId;
+
+        // Always flush the default scope.
+        UserScopedCache::flush($userIdString, null);
+
+        if (null !== $groupId) {
+            UserScopedCache::flush($userIdString, (string) $groupId);
+        }
+
+        $user = User::find($userId);
+        if (null === $user) {
+            return;
+        }
+
+        $groupIds = $user
+            ->groupMemberships()
+            ->pluck('user_group_id')
+            ->filter(static fn ($membershipGroupId): bool => null !== $membershipGroupId)
+            ->map(static fn ($membershipGroupId): string => (string) $membershipGroupId);
+
+        if (null !== $user->user_group_id) {
+            $groupIds->push((string) $user->user_group_id);
+        }
+
+        $groupIds
+            ->unique()
+            ->each(static function (string $membershipGroupId) use ($userIdString): void {
+                UserScopedCache::flush($userIdString, $membershipGroupId);
+            });
     }
 }

--- a/tests/integration/AI/DebtSimulationCacheInvalidationTest.php
+++ b/tests/integration/AI/DebtSimulationCacheInvalidationTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Tests\integration\AI;
 
 use FireflyIII\Models\Account;
+use FireflyIII\Enums\UserRoleEnum;
+use FireflyIII\Models\GroupMembership;
+use FireflyIII\Models\UserGroup;
+use FireflyIII\Models\UserRole;
 use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
 use FireflyIII\User;
 use Illuminate\Support\Facades\Cache;
@@ -78,15 +82,134 @@ final class DebtSimulationCacheInvalidationTest extends TestCase
 
     public function testFlushesCacheOnUserDeleted(): void
     {
-        $user                 = new User();
-        $user->id             = 1;
-        $user->user_group_id  = 1;
+        $user      = $this->createUserWithGroups();
+        $memberships = $user->groupMemberships()->get();
+        $groupIds = $memberships->pluck('user_group_id')->map(static fn ($id): string => (string) $id)->all();
 
-        $key = $this->seedCachedSimulation('1', '1');
-        self::assertTrue(Cache::has($key));
+        $defaultKey = $this->seedCachedSimulation((string) $user->id, null);
+        $groupKeys  = array_map(fn (string $groupId): string => $this->seedCachedSimulation((string) $user->id, $groupId), $groupIds);
 
+        self::assertTrue(Cache::has($defaultKey));
+        foreach ($groupKeys as $key) {
+            self::assertTrue(Cache::has($key));
+        }
+
+        $user->load('groupMemberships');
         event('eloquent.deleted: ' . User::class, $user);
 
-        self::assertFalse(Cache::has($key));
+        self::assertFalse(Cache::has($defaultKey));
+        foreach ($groupKeys as $key) {
+            self::assertFalse(Cache::has($key));
+        }
+    }
+
+    public function testFlushesPrimaryGroupCacheOnUserDeletedWhenMembershipMissing(): void
+    {
+        $user             = $this->createUserWithGroups(includePrimaryMembership: false);
+        $memberships      = $user->groupMemberships()->get();
+        $primaryGroupId   = (string) $user->user_group_id;
+        $secondaryGroupId = $memberships
+            ->pluck('user_group_id')
+            ->reject(static fn ($groupId): bool => (int) $groupId === (int) $user->user_group_id)
+            ->map(static fn ($groupId): string => (string) $groupId)
+            ->first();
+
+        self::assertNotNull($secondaryGroupId);
+
+        $defaultKey   = $this->seedCachedSimulation((string) $user->id, null);
+        $primaryKey   = $this->seedCachedSimulation((string) $user->id, $primaryGroupId);
+        $secondaryKey = $this->seedCachedSimulation((string) $user->id, $secondaryGroupId);
+
+        self::assertTrue(Cache::has($defaultKey));
+        self::assertTrue(Cache::has($primaryKey));
+        self::assertTrue(Cache::has($secondaryKey));
+
+        $user->load('groupMemberships');
+        event('eloquent.deleted: ' . User::class, $user);
+
+        self::assertFalse(Cache::has($defaultKey));
+        self::assertFalse(Cache::has($primaryKey));
+        self::assertFalse(Cache::has($secondaryKey));
+    }
+
+    public function testFlushesCacheForAllGroupsOnMembershipUpdated(): void
+    {
+        $user         = $this->createUserWithGroups();
+        $memberships  = $user->groupMemberships()->get();
+        $groupIds     = $memberships->pluck('user_group_id')->map(static fn ($id): string => (string) $id)->all();
+        $defaultKey   = $this->seedCachedSimulation((string) $user->id, null);
+        $groupKeys    = array_map(fn (string $groupId): string => $this->seedCachedSimulation((string) $user->id, $groupId), $groupIds);
+
+        self::assertTrue(Cache::has($defaultKey));
+        foreach ($groupKeys as $key) {
+            self::assertTrue(Cache::has($key));
+        }
+
+        $membership = $memberships->first();
+        $newRoleId  = UserRole::where('title', UserRoleEnum::MANAGE_TRANSACTIONS)->firstOrFail()->id;
+        $membership->update(['user_role_id' => $newRoleId]);
+
+        self::assertFalse(Cache::has($defaultKey));
+        foreach ($groupKeys as $key) {
+            self::assertFalse(Cache::has($key));
+        }
+    }
+
+    public function testFlushesCacheForAllGroupsOnMembershipDeleted(): void
+    {
+        $user         = $this->createUserWithGroups();
+        $memberships  = $user->groupMemberships()->get();
+        $groupIds     = $memberships->pluck('user_group_id')->map(static fn ($id): string => (string) $id)->all();
+        $defaultKey   = $this->seedCachedSimulation((string) $user->id, null);
+        $groupKeys    = array_map(fn (string $groupId): string => $this->seedCachedSimulation((string) $user->id, $groupId), $groupIds);
+
+        self::assertTrue(Cache::has($defaultKey));
+        foreach ($groupKeys as $key) {
+            self::assertTrue(Cache::has($key));
+        }
+
+        $memberships->first()->delete();
+
+        self::assertFalse(Cache::has($defaultKey));
+        foreach ($groupKeys as $key) {
+            self::assertFalse(Cache::has($key));
+        }
+    }
+
+    private function createUserWithGroups(bool $includePrimaryMembership = true): User
+    {
+        $primaryGroup = UserGroup::create(['title' => 'Primary Group']);
+        $secondary    = UserGroup::create(['title' => 'Secondary Group']);
+
+        $user = User::create([
+            'email'         => 'user-' . uniqid('', true) . '@example.com',
+            'password'      => bcrypt('secret'),
+            'user_group_id' => $primaryGroup->id,
+        ]);
+
+        $roleId = UserRole::where('title', UserRoleEnum::FULL)->firstOrFail()->id;
+
+        if ($includePrimaryMembership) {
+            GroupMembership::create([
+                'user_id'       => $user->id,
+                'user_group_id' => $primaryGroup->id,
+                'user_role_id'  => $roleId,
+            ]);
+        } else {
+            GroupMembership::where('user_id', $user->id)
+                ->where('user_group_id', $primaryGroup->id)
+                ->delete();
+
+            $user->forceFill(['user_group_id' => $primaryGroup->id])->save();
+            $user->refresh();
+        }
+
+        GroupMembership::create([
+            'user_id'       => $user->id,
+            'user_group_id' => $secondary->id,
+            'user_role_id'  => $roleId,
+        ]);
+
+        return $user;
     }
 }


### PR DESCRIPTION
## Summary
- ensure debt simulation cache flushing includes the user’s primary group scope even when no membership record exists
- update the group membership listener to clear the primary group scope alongside all active memberships
- extend the debt simulation cache invalidation integration tests with coverage for users missing a primary-group membership

## Testing
- vendor/bin/phpunit tests/integration/AI/DebtSimulationCacheInvalidationTest.php
- APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpstan analyse app/Listeners/FlushDebtSimulationCache.php app/Listeners/UserGroupMembershipChanged.php --no-progress --memory-limit=512M


------
https://chatgpt.com/codex/tasks/task_e_68e91a29bf70832687d4974db07331b7