### PR TITLE
Add slippage-aware metrics for cross-pairs backtests

### DIFF
--- a/fe/strategies/cross_pairs.py
+++ b/fe/strategies/cross_pairs.py
@@ -6,7 +6,7 @@ pairs trading strategies that exploit correlations across related markets.
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Tuple
+from typing import Any, Callable, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -64,21 +64,42 @@ def compute_signals(
     return signals.fillna(0.0)
 
 
+SlippageModel = Callable[[pd.DataFrame, pd.DataFrame], pd.Series]
+
+
 def vectorized_backtest(
     prices: pd.DataFrame,
     pairs: Sequence[Pair],
     lookback: int = 20,
     threshold: float = 1.0,
-) -> pd.Series:
+    slippage: float | SlippageModel = 0.0,
+) -> tuple[pd.Series, pd.Series]:
     """Run a vectorised backtest of the cross-pairs strategy.
 
     The strategy enters positions based on :func:`compute_signals` and
-    realises profit and loss from the subsequent period's returns.
+    realises profit and loss from the subsequent period's returns.  Optional
+    ``slippage`` costs are deducted whenever the position changes.
+
+    Parameters
+    ----------
+    prices:
+        DataFrame containing price series for each market.
+    pairs:
+        Sequence of market column pairs.
+    lookback:
+        Rolling window used to compute z-scores.
+    threshold:
+        Z-score magnitude required to open a position.
+    slippage:
+        Either a scalar cost applied per unit turnover or a callable returning
+        a per-period cost ``Series`` given the absolute position changes and
+        per-pair returns.
 
     Returns
     -------
-    pd.Series
-        Cumulative profit and loss over time assuming unit capital per pair.
+    tuple[pd.Series, pd.Series]
+        Tuple containing the per-period returns (first element) and cumulative
+        PnL (second element).
     """
     signals = compute_signals(prices, pairs, lookback, threshold)
 
@@ -88,8 +109,22 @@ def vectorized_backtest(
         index=prices.index,
     )
 
-    pnl = (signals * pair_returns).sum(axis=1).fillna(0.0)
-    return pnl.cumsum()
+    per_pair_pnl = (signals * pair_returns).fillna(0.0)
+    per_period = per_pair_pnl.sum(axis=1)
+
+    trades = signals.diff().abs().fillna(0.0)
+    if callable(slippage):
+        slip_cost = slippage(trades, pair_returns)
+    else:
+        slip_cost = trades.sum(axis=1) * float(slippage)
+
+    if isinstance(slip_cost, pd.Series):
+        slip_cost = slip_cost.reindex(per_period.index).fillna(0.0)
+    else:
+        slip_cost = pd.Series(slip_cost, index=per_period.index).fillna(0.0)
+    per_period = (per_period - slip_cost).fillna(0.0)
+    cumulative = per_period.cumsum()
+    return per_period, cumulative
 
 
 def grid_search(
@@ -107,8 +142,9 @@ def grid_search(
     results: dict[tuple[int, float], float] = {}
     for lb in lookbacks:
         for th in thresholds:
-            pnl = vectorized_backtest(prices, pairs, lb, th).iloc[-1]
-            results[(lb, th)] = pnl
+            _, cumulative = vectorized_backtest(prices, pairs, lb, th)
+            pnl = cumulative.iloc[-1] if not cumulative.empty else 0.0
+            results[(lb, th)] = float(pnl)
 
     df = pd.Series(results).unstack()
     df.index.name = "lookback"
@@ -121,6 +157,7 @@ def shuffled_label_significance(
     pairs: Sequence[Pair],
     lookback: int,
     threshold: float,
+    slippage: float | SlippageModel = 0.0,
     n_shuffles: int = 100,
     seed: int | None = None,
 ) -> tuple[float, np.ndarray, float]:
@@ -141,20 +178,95 @@ def shuffled_label_significance(
         Proportion of shuffled outcomes greater than or equal to ``actual``.
     """
     rng = np.random.default_rng(seed)
-    actual = vectorized_backtest(prices, pairs, lookback, threshold).iloc[-1]
+    _, actual_cumulative = vectorized_backtest(
+        prices, pairs, lookback, threshold, slippage=slippage
+    )
+    actual = float(actual_cumulative.iloc[-1]) if not actual_cumulative.empty else 0.0
 
     shuffled = []
     for _ in range(n_shuffles):
         shuffled_prices = prices.copy()
         shuffled_prices.columns = rng.permutation(shuffled_prices.columns)
-        pnl = vectorized_backtest(
-            shuffled_prices, pairs, lookback, threshold
-        ).iloc[-1]
+        _, shuffled_cumulative = vectorized_backtest(
+            shuffled_prices, pairs, lookback, threshold, slippage=slippage
+        )
+        pnl = (
+            float(shuffled_cumulative.iloc[-1])
+            if not shuffled_cumulative.empty
+            else 0.0
+        )
         shuffled.append(pnl)
 
     shuffled_arr = np.asarray(shuffled)
     p_value = (np.sum(shuffled_arr >= actual) + 1) / (n_shuffles + 1)
     return actual, shuffled_arr, p_value
+
+
+def compute_backtest_metrics(
+    prices: pd.DataFrame,
+    pairs: Sequence[Pair],
+    *,
+    lookback: int = 20,
+    threshold: float = 1.0,
+    slippage: float | SlippageModel = 0.0,
+    n_shuffles: int = 0,
+    seed: int | None = None,
+) -> dict[str, Any]:
+    """Return performance metrics for the cross-pairs strategy.
+
+    The helper wraps :func:`vectorized_backtest` and augments the resulting
+    return series with common statistics such as Sharpe ratio and drawdown.  If
+    ``n_shuffles`` is positive, a shuffled-label significance test is
+    performed to estimate a one-sided p-value.
+    """
+
+    returns, cumulative = vectorized_backtest(
+        prices, pairs, lookback, threshold, slippage=slippage
+    )
+
+    pnl = float(cumulative.iloc[-1]) if not cumulative.empty else 0.0
+
+    std = float(returns.std(ddof=0))
+    sharpe = 0.0
+    if std > 0:
+        sharpe = float(returns.mean() / std * np.sqrt(252))
+
+    if cumulative.empty:
+        max_drawdown = 0.0
+    else:
+        running_max = cumulative.cummax()
+        drawdown = cumulative - running_max
+        max_drawdown = float(drawdown.min())
+
+    non_zero = returns[returns != 0.0]
+    hit_rate = float((non_zero > 0).mean()) if not non_zero.empty else float("nan")
+
+    signals = compute_signals(prices, pairs, lookback, threshold)
+    turnover_series = signals.diff().abs().sum(axis=1).fillna(0.0)
+    turnover = float(turnover_series.mean()) if not turnover_series.empty else 0.0
+
+    p_value = float("nan")
+    if n_shuffles > 0:
+        _, _, p_value = shuffled_label_significance(
+            prices,
+            pairs,
+            lookback,
+            threshold,
+            slippage=slippage,
+            n_shuffles=n_shuffles,
+            seed=seed,
+        )
+
+    return {
+        "returns": returns,
+        "cumulative": cumulative,
+        "pnl": pnl,
+        "sharpe": float(sharpe),
+        "max_drawdown": max_drawdown,
+        "hit_rate": hit_rate,
+        "turnover": turnover,
+        "p_value": float(p_value),
+    }
 
 
 class Strategy(RuntimeStrategy):
@@ -176,8 +288,23 @@ class Strategy(RuntimeStrategy):
     def compute_signals(self, prices: pd.DataFrame) -> pd.DataFrame:
         return compute_signals(prices, self.pairs, self.lookback, self.threshold)
 
-    def backtest(self, prices: pd.DataFrame) -> pd.Series:
-        return vectorized_backtest(prices, self.pairs, self.lookback, self.threshold)
+    def backtest(
+        self,
+        prices: pd.DataFrame,
+        *,
+        slippage: float | SlippageModel = 0.0,
+        n_shuffles: int = 0,
+        seed: int | None = None,
+    ) -> dict[str, Any]:
+        return compute_backtest_metrics(
+            prices,
+            self.pairs,
+            lookback=self.lookback,
+            threshold=self.threshold,
+            slippage=slippage,
+            n_shuffles=n_shuffles,
+            seed=seed,
+        )
 
     # Runtime interface -------------------------------------------------------
     def propose_orders(self, market_state: Any) -> dict[str, Any]:
@@ -213,5 +340,6 @@ __all__ = [
     "vectorized_backtest",
     "grid_search",
     "shuffled_label_significance",
+    "compute_backtest_metrics",
     "Strategy",
 ]

--- a/tests/fe/strategies/test_cross_pairs.py
+++ b/tests/fe/strategies/test_cross_pairs.py
@@ -8,10 +8,12 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from fe.strategies.cross_pairs import (  # noqa: E402
+    compute_backtest_metrics,
     compute_signals,
     grid_search,
     shuffled_label_significance,
     vectorized_backtest,
+    Strategy,
 )
 
 
@@ -52,21 +54,72 @@ def test_compute_signals_matches_expected_pattern():
 
 def test_vectorized_backtest_agrees_with_manual_pnl():
     prices = make_price_frame()
-    pnl = vectorized_backtest(prices, PAIR_DEFINITION, lookback=5, threshold=0.8)
+    period_returns, cumulative = vectorized_backtest(
+        prices, PAIR_DEFINITION, lookback=5, threshold=0.8
+    )
 
-    assert pnl.index.equals(prices.index)
+    assert period_returns.index.equals(prices.index)
+    assert cumulative.index.equals(prices.index)
     signals = compute_signals(prices, PAIR_DEFINITION, lookback=5, threshold=0.8)
-    returns = prices.pct_change().shift(-1)
+    price_returns = prices.pct_change().shift(-1)
     pair_returns = pd.DataFrame(
         {
-            f"{a}/{b}": returns[a] - returns[b]
+            f"{a}/{b}": price_returns[a] - price_returns[b]
             for a, b in PAIR_DEFINITION
         },
         index=prices.index,
     )
-    expected = (signals * pair_returns).sum(axis=1).fillna(0.0).cumsum()
+    per_pair = (signals * pair_returns).sum(axis=1).fillna(0.0)
+    expected_cumulative = per_pair.cumsum()
 
-    pd.testing.assert_series_equal(pnl, expected, check_freq=False)
+    pd.testing.assert_series_equal(period_returns, per_pair, check_freq=False)
+    pd.testing.assert_series_equal(cumulative, expected_cumulative, check_freq=False)
+
+
+def test_vectorized_backtest_applies_slippage():
+    prices = make_price_frame()
+    returns, _ = vectorized_backtest(
+        prices, PAIR_DEFINITION, lookback=5, threshold=0.8, slippage=0.1
+    )
+    signals = compute_signals(prices, PAIR_DEFINITION, lookback=5, threshold=0.8)
+    pct = prices.pct_change().shift(-1)
+    pair_returns = pd.DataFrame(
+        {f"{a}/{b}": pct[a] - pct[b] for a, b in PAIR_DEFINITION},
+        index=prices.index,
+    )
+    gross = (signals * pair_returns).sum(axis=1).fillna(0.0)
+    trades = signals.diff().abs().sum(axis=1).fillna(0.0)
+    expected = gross - 0.1 * trades
+
+    pd.testing.assert_series_equal(returns, expected, check_freq=False)
+
+
+def test_vectorized_backtest_supports_callable_slippage():
+    prices = make_price_frame()
+
+    def slip_model(trades: pd.DataFrame, pair_returns: pd.DataFrame) -> pd.Series:
+        base_cost = trades.sum(axis=1)
+        spread_cost = pair_returns.abs().sum(axis=1)
+        return 0.05 * base_cost + 0.01 * spread_cost
+
+    returns, _ = vectorized_backtest(
+        prices,
+        PAIR_DEFINITION,
+        lookback=5,
+        threshold=0.8,
+        slippage=slip_model,
+    )
+
+    signals = compute_signals(prices, PAIR_DEFINITION, lookback=5, threshold=0.8)
+    pct = prices.pct_change().shift(-1)
+    pair_returns = pd.DataFrame(
+        {f"{a}/{b}": pct[a] - pct[b] for a, b in PAIR_DEFINITION},
+        index=prices.index,
+    )
+    gross = (signals * pair_returns).sum(axis=1).fillna(0.0)
+    expected = gross - slip_model(signals.diff().abs().fillna(0.0), pair_returns)
+
+    pd.testing.assert_series_equal(returns, expected.fillna(0.0), check_freq=False)
 
 
 def test_grid_search_collates_backtest_results():
@@ -79,12 +132,12 @@ def test_grid_search_collates_backtest_results():
     expected = pd.DataFrame(
         {
             0.6: [
-                vectorized_backtest(prices, PAIR_DEFINITION, 4, 0.6).iloc[-1],
-                vectorized_backtest(prices, PAIR_DEFINITION, 5, 0.6).iloc[-1],
+                vectorized_backtest(prices, PAIR_DEFINITION, 4, 0.6)[1].iloc[-1],
+                vectorized_backtest(prices, PAIR_DEFINITION, 5, 0.6)[1].iloc[-1],
             ],
             0.8: [
-                vectorized_backtest(prices, PAIR_DEFINITION, 4, 0.8).iloc[-1],
-                vectorized_backtest(prices, PAIR_DEFINITION, 5, 0.8).iloc[-1],
+                vectorized_backtest(prices, PAIR_DEFINITION, 4, 0.8)[1].iloc[-1],
+                vectorized_backtest(prices, PAIR_DEFINITION, 5, 0.8)[1].iloc[-1],
             ],
         },
         index=pd.Index(lookbacks, name="lookback"),
@@ -103,11 +156,63 @@ def test_shuffled_label_significance_returns_plausible_distribution():
     )
 
     assert actual == pytest.approx(
-        vectorized_backtest(prices, PAIR_DEFINITION, lookback, threshold).iloc[-1]
+        vectorized_backtest(prices, PAIR_DEFINITION, lookback, threshold)[1].iloc[-1]
     )
     assert shuffled.shape == (25,)
     assert np.all(np.isfinite(shuffled))
     assert 0.0 < p_value < 1.0
+
+
+def test_compute_backtest_metrics_returns_expected_statistics():
+    prices = make_price_frame()
+    metrics = compute_backtest_metrics(
+        prices,
+        PAIR_DEFINITION,
+        lookback=5,
+        threshold=0.8,
+        slippage=0.05,
+        n_shuffles=5,
+        seed=7,
+    )
+
+    assert set(metrics) == {
+        "returns",
+        "cumulative",
+        "pnl",
+        "sharpe",
+        "max_drawdown",
+        "hit_rate",
+        "turnover",
+        "p_value",
+    }
+    assert isinstance(metrics["returns"], pd.Series)
+    assert isinstance(metrics["cumulative"], pd.Series)
+
+    base_returns, base_cumulative = vectorized_backtest(
+        prices, PAIR_DEFINITION, lookback=5, threshold=0.8, slippage=0.05
+    )
+    pd.testing.assert_series_equal(metrics["returns"], base_returns, check_freq=False)
+    pd.testing.assert_series_equal(
+        metrics["cumulative"], base_cumulative, check_freq=False
+    )
+
+    assert np.isfinite(metrics["pnl"])
+    assert np.isfinite(metrics["sharpe"])
+    assert metrics["max_drawdown"] <= 0.0
+    assert 0.0 <= metrics["turnover"]
+    assert np.isnan(metrics["hit_rate"]) or 0.0 <= metrics["hit_rate"] <= 1.0
+    assert 0.0 < metrics["p_value"] <= 1.0
+
+
+def test_strategy_backtest_exposes_metrics_dict():
+    prices = make_price_frame()
+    strat = Strategy(PAIR_DEFINITION, lookback=5, threshold=0.8)
+
+    metrics = strat.backtest(prices, slippage=0.02, n_shuffles=3, seed=99)
+
+    assert isinstance(metrics, dict)
+    assert metrics["returns"].index.equals(prices.index)
+    assert metrics["cumulative"].index.equals(prices.index)
 
 
 def test_missing_columns_raise_key_error():


### PR DESCRIPTION
## Summary
- extend the cross-pairs backtest to support configurable slippage and expose per-period and cumulative results
- add a helper that computes PnL, Sharpe, drawdown, hit-rate, turnover, and shuffled-label significance with a metrics-focused Strategy.backtest API
- update the cross-pairs tests to validate the new metrics workflow, slippage handling, and shuffled significance integration

## Testing
- pytest tests/fe/strategies/test_cross_pairs.py

------
https://chatgpt.com/codex/tasks/task_e_68ee650b899483269ec9625d43086faa