### PR TITLE
Add per-period PnL metrics to maker strategy backtests

### DIFF
--- a/fe/strategies/maker.py
+++ b/fe/strategies/maker.py
@@ -12,6 +12,7 @@ import itertools
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Mapping, Tuple
 
+import numpy as np
 import pandas as pd
 
 from fe.strategies.runtime import RuntimeStrategy, ensure_dataframe, latest_row
@@ -95,18 +96,60 @@ def run_backtest(
 
     bid_edge = qdf["bid"] - df["yes"] - slippage
     ask_edge = df["no"] - qdf["ask"] - slippage
-    pnl = 0.5 * (bid_edge + ask_edge)
+    period_pnl = 0.5 * (bid_edge + ask_edge)
+    turnover = bid_edge.abs() + ask_edge.abs()
 
-    return pd.DataFrame({"bid_edge": bid_edge, "ask_edge": ask_edge, "pnl": pnl})
+    return pd.DataFrame(
+        {
+            "bid_edge": bid_edge,
+            "ask_edge": ask_edge,
+            "turnover": turnover,
+            "pnl": period_pnl,
+        }
+    )
 
 
-def performance_metrics(results: pd.DataFrame) -> Dict[str, float]:
-    """Compute summary metrics from backtest results."""
+def pnl_metrics(
+    pnl: pd.Series,
+    *,
+    n_shuffle: int = 0,
+    seed: int | None = None,
+    trading_periods: int = 252,
+) -> Dict[str, float]:
+    """Compute summary metrics from a per-period PnL series."""
 
-    trades = results[["bid_edge", "ask_edge"]].stack()
-    win_rate = float((trades > 0).mean())
-    mean_pnl = float(results["pnl"].mean())
-    return {"mean_pnl": mean_pnl, "win_rate": win_rate}
+    pnl = pnl.astype(float)
+    total_pnl = float(pnl.sum()) if not pnl.empty else 0.0
+    sharpe = 0.0
+    std = pnl.std(ddof=0)
+    if std > 0:
+        sharpe = float(pnl.mean() / std * np.sqrt(trading_periods))
+
+    equity = pnl.cumsum()
+    max_drawdown = 0.0
+    if not equity.empty:
+        running_max = equity.cummax()
+        max_drawdown = float((equity - running_max).min())
+
+    hit_rate = float((pnl > 0).mean()) if not pnl.empty else 0.0
+    turnover = float(pnl.abs().sum()) if not pnl.empty else 0.0
+
+    p_value = float("nan")
+    if n_shuffle > 0 and not pnl.empty:
+        rng = np.random.default_rng(seed)
+        arr = pnl.to_numpy()
+        shuffled = [rng.permutation(arr).sum() for _ in range(n_shuffle)]
+        sh_arr = np.asarray(shuffled)
+        p_value = float((np.sum(sh_arr >= total_pnl) + 1) / (n_shuffle + 1))
+
+    return {
+        "pnl": total_pnl,
+        "sharpe": float(sharpe),
+        "max_drawdown": float(max_drawdown),
+        "hit_rate": hit_rate,
+        "turnover": turnover,
+        "p_value": float(p_value),
+    }
 
 
 def tune_parameters(
@@ -127,8 +170,8 @@ def tune_parameters(
         res = run_backtest(
             df, spread=s, liq_weight=lw, skew_weight=sw, slippage=slippage
         )
-        metrics = performance_metrics(res)
-        score = metrics["mean_pnl"]
+        metrics = pnl_metrics(res["pnl"])
+        score = metrics["pnl"]
         if score > best_score:
             best_score = score
             best_params = {"spread": s, "liq_weight": lw, "skew_weight": sw}
@@ -167,14 +210,23 @@ class Strategy(RuntimeStrategy):
             skew_weight=self.skew_weight,
         )
 
-    def backtest(self, df: pd.DataFrame) -> pd.DataFrame:
-        return run_backtest(
+    def backtest(
+        self,
+        df: pd.DataFrame,
+        *,
+        price_col: str | None = None,
+        n_shuffle: int = 100,
+        seed: int | None = None,
+    ) -> Dict[str, Any]:
+        results = run_backtest(
             df,
             spread=self.spread,
             liq_weight=self.liq_weight,
             skew_weight=self.skew_weight,
             slippage=self.slippage,
         )
+        metrics = pnl_metrics(results["pnl"], n_shuffle=n_shuffle, seed=seed)
+        return {"pnl_series": results["pnl"], **metrics}
 
     # Runtime interface -------------------------------------------------------
     def propose_orders(self, market_state: Any) -> Dict[str, Any]:

--- a/tests/fe/strategies/test_maker.py
+++ b/tests/fe/strategies/test_maker.py
@@ -1,9 +1,13 @@
 import sys
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from fe.strategies.maker import make_quote
+from fe.strategies.maker import Strategy, make_quote, pnl_metrics, run_backtest
 
 
 def test_extreme_liquidity_quote_is_not_inverted():
@@ -20,3 +24,72 @@ def test_extreme_liquidity_quote_is_not_inverted():
     assert quote.bid <= quote.ask
     assert 0.0 <= quote.bid <= 1.0
     assert 0.0 <= quote.ask <= 1.0
+
+
+def _sample_backtest_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "yes": [0.45, 0.48, 0.44, 0.5, 0.47],
+            "no": [0.55, 0.52, 0.56, 0.5, 0.53],
+            "liquidity": [0.2, 0.8, 0.4, 0.1, 0.6],
+            "skew": [0.0, 0.1, -0.2, 0.05, -0.05],
+        }
+    )
+
+
+def test_run_backtest_returns_slippage_adjusted_pnl_series():
+    df = _sample_backtest_frame()
+
+    no_slip = run_backtest(
+        df, spread=0.02, liq_weight=0.5, skew_weight=0.5, slippage=0.0
+    )
+    slip = run_backtest(
+        df, spread=0.02, liq_weight=0.5, skew_weight=0.5, slippage=0.01
+    )
+
+    assert "pnl" in no_slip
+    assert "turnover" in no_slip
+    assert len(no_slip) == len(df)
+    assert np.all(no_slip["pnl"] >= slip["pnl"])
+
+
+def test_pnl_metrics_computes_expected_statistics():
+    pnl = pd.Series([0.1, -0.05, 0.2, -0.1])
+
+    metrics = pnl_metrics(pnl, n_shuffle=10, seed=1, trading_periods=4)
+
+    expected_pnl = float(pnl.sum())
+    expected_sharpe = float(pnl.mean() / pnl.std(ddof=0) * np.sqrt(4))
+    equity = pnl.cumsum()
+    expected_drawdown = float((equity - equity.cummax()).min())
+    expected_hit_rate = float((pnl > 0).mean())
+    expected_turnover = float(pnl.abs().sum())
+
+    rng = np.random.default_rng(1)
+    shuffled = [rng.permutation(pnl.to_numpy()).sum() for _ in range(10)]
+    expected_p_value = float((np.sum(np.array(shuffled) >= expected_pnl) + 1) / 11)
+
+    assert metrics["pnl"] == pytest.approx(expected_pnl)
+    assert metrics["sharpe"] == pytest.approx(expected_sharpe)
+    assert metrics["max_drawdown"] == pytest.approx(expected_drawdown)
+    assert metrics["hit_rate"] == pytest.approx(expected_hit_rate)
+    assert metrics["turnover"] == pytest.approx(expected_turnover)
+    assert metrics["p_value"] == pytest.approx(expected_p_value)
+
+
+def test_strategy_backtest_returns_metrics_and_series():
+    df = _sample_backtest_frame()
+    strat = Strategy(spread=0.02, liq_weight=0.4, skew_weight=0.6, slippage=0.005)
+
+    metrics = strat.backtest(df, n_shuffle=5, seed=123)
+
+    expected = run_backtest(
+        df, spread=0.02, liq_weight=0.4, skew_weight=0.6, slippage=0.005
+    )
+
+    assert set(
+        ["pnl", "sharpe", "max_drawdown", "hit_rate", "turnover", "p_value", "pnl_series"]
+    ).issubset(metrics)
+    assert metrics["pnl_series"].equals(expected["pnl"])
+    assert isinstance(metrics["p_value"], float)
+    assert 0.0 <= metrics["p_value"] <= 1.0


### PR DESCRIPTION
## Summary
- add per-period PnL metrics and shuffled-label significance calculations to the maker strategy backtest
- update the maker runtime strategy to surface the new metrics for walk-forward validation
- expand maker strategy unit tests to validate the per-period PnL series and summary statistics

## Testing
- pytest tests/fe/strategies/test_maker.py

------
https://chatgpt.com/codex/tasks/task_e_68f2400818688326b58b43098cc87b1d