### PR TITLE
Enhance rules alpha performance metrics

### DIFF
--- a/fe/strategies/rules_alpha.py
+++ b/fe/strategies/rules_alpha.py
@@ -67,7 +67,15 @@ def simulate(df: pd.DataFrame, threshold: float, slippage: SlippageModel) -> pd.
     """
 
     if df.empty:
-        return pd.Series(dtype=float)
+        returns = pd.Series(dtype=float)
+        returns.attrs["meta"] = {
+            "prices": [],
+            "rules": [],
+            "threshold": float(threshold),
+            "slippage": float(slippage.rate),
+            "positions": [],
+        }
+        return returns
 
     alpha = _score_rules(df["rule"].tolist())
     side = np.where(alpha >= threshold, 1, -1)
@@ -75,18 +83,95 @@ def simulate(df: pd.DataFrame, threshold: float, slippage: SlippageModel) -> pd.
     executed = np.array([slippage.apply(p, s) for p, s in zip(prices, side)])
     # Compute P&L from price changes in direction of the position.
     pnl = (np.roll(executed, -1) - executed) * side
-    return pd.Series(pnl[:-1], index=df.index[:-1])
+    returns = pd.Series(pnl[:-1], index=df.index[:-1])
+    returns.attrs["meta"] = {
+        "prices": prices.tolist(),
+        "rules": df["rule"].tolist(),
+        "threshold": float(threshold),
+        "slippage": float(slippage.rate),
+        "positions": side[:-1].tolist(),
+    }
+    return returns
 
 
-def performance_report(returns: pd.Series) -> Dict[str, float]:
-    """Compute basic performance statistics."""
+def performance_report(
+    returns: pd.Series,
+    *,
+    permutations: int = 200,
+    seed: int | None = 0,
+) -> Dict[str, float]:
+    """Compute comprehensive performance statistics."""
 
     if returns.empty:
-        return {"trades": 0, "avg_return": 0.0, "sharpe": 0.0}
+        return {
+            "trades": 0,
+            "avg_return": 0.0,
+            "pnl": 0.0,
+            "sharpe": 0.0,
+            "max_drawdown": 0.0,
+            "hit_rate": 0.0,
+            "turnover": 0.0,
+            "p_value": float("nan"),
+        }
+
+    pnl = float(returns.sum())
     avg = float(returns.mean())
     std = float(returns.std(ddof=0))
     sharpe = avg / std if std else 0.0
-    return {"trades": int(returns.size), "avg_return": avg, "sharpe": sharpe}
+
+    cumulative = np.cumsum(returns.to_numpy())
+    equity = np.concatenate(([0.0], cumulative))
+    running_max = np.maximum.accumulate(equity)
+    drawdowns = equity - running_max
+    max_drawdown = float(drawdowns.min())
+
+    hit_rate = float(np.mean(returns.to_numpy() > 0))
+
+    meta = returns.attrs.get("meta", {})
+    positions = np.asarray(meta.get("positions", []), dtype=float)
+    if positions.size:
+        deltas = np.diff(np.concatenate(([0.0], positions)))
+        turnover = float(np.sum(np.abs(deltas)))
+    else:
+        turnover = 0.0
+
+    prices = meta.get("prices")
+    rules = meta.get("rules")
+    threshold = meta.get("threshold")
+    slippage = meta.get("slippage")
+    if (
+        permutations > 0
+        and prices is not None
+        and rules is not None
+        and threshold is not None
+        and slippage is not None
+        and len(prices) > 1
+    ):
+        rng = np.random.default_rng(seed)
+        base_df = pd.DataFrame({"price": prices, "rule": rules})
+        sample = np.empty(permutations, dtype=float)
+        for i in range(permutations):
+            shuffled = rng.permutation(rules)
+            simulated = simulate(
+                base_df.assign(rule=shuffled),
+                float(threshold),
+                SlippageModel(rate=float(slippage)),
+            )
+            sample[i] = float(simulated.mean()) if not simulated.empty else 0.0
+        p_value = float((np.sum(sample >= avg) + 1) / (permutations + 1))
+    else:
+        p_value = float("nan")
+
+    return {
+        "trades": int(returns.size),
+        "avg_return": avg,
+        "pnl": pnl,
+        "sharpe": sharpe,
+        "max_drawdown": max_drawdown,
+        "hit_rate": hit_rate,
+        "turnover": turnover,
+        "p_value": p_value,
+    }
 
 
 def grid_search(df: pd.DataFrame, thresholds: Iterable[float], slippages: Iterable[float]) -> Dict[str, Any]:

--- a/tests/fe/strategies/test_rules_alpha.py
+++ b/tests/fe/strategies/test_rules_alpha.py
@@ -47,11 +47,42 @@ def test_simulate_and_performance_report(sample_frame: pd.DataFrame) -> None:
     model = SlippageModel(rate=0.0)
     returns = simulate(data, threshold=0.5, slippage=model)
     assert returns.tolist() == pytest.approx([0.2, 0.05, 0.05])
+    assert returns.attrs["meta"]["positions"] == [1, -1, -1]
 
-    report = performance_report(returns)
-    assert report["trades"] == 3
-    assert report["avg_return"] == pytest.approx(0.1)
-    assert report["sharpe"] == pytest.approx(np.sqrt(2))
+    permutations = 200
+    report = performance_report(returns, permutations=permutations, seed=123)
+    expected_keys = {
+        "trades",
+        "avg_return",
+        "pnl",
+        "sharpe",
+        "max_drawdown",
+        "hit_rate",
+        "turnover",
+        "p_value",
+    }
+    assert set(report.keys()) == expected_keys
+
+    rng = np.random.default_rng(123)
+    shuffled_means = []
+    for _ in range(permutations):
+        shuffled_frame = data.assign(rule=rng.permutation(data["rule"].to_numpy()))
+        shuffled_returns = simulate(shuffled_frame, threshold=0.5, slippage=model)
+        shuffled_means.append(shuffled_returns.mean() if not shuffled_returns.empty else 0.0)
+    expected_p = (np.sum(np.array(shuffled_means) >= report["avg_return"]) + 1) / (
+        permutations + 1
+    )
+
+    assert report == {
+        "trades": 3,
+        "avg_return": pytest.approx(0.1),
+        "pnl": pytest.approx(0.3),
+        "sharpe": pytest.approx(np.sqrt(2)),
+        "max_drawdown": pytest.approx(0.0),
+        "hit_rate": pytest.approx(1.0),
+        "turnover": pytest.approx(3.0),
+        "p_value": pytest.approx(expected_p),
+    }
 
 
 def test_score_rules_and_slippage_model_behaviour() -> None:
@@ -77,7 +108,25 @@ def test_simulate_and_report_empty_inputs() -> None:
     assert returns.dtype == float
 
     report = performance_report(returns)
-    assert report == {"trades": 0, "avg_return": 0.0, "sharpe": 0.0}
+    expected_keys = {
+        "trades",
+        "avg_return",
+        "pnl",
+        "sharpe",
+        "max_drawdown",
+        "hit_rate",
+        "turnover",
+        "p_value",
+    }
+    assert set(report.keys()) == expected_keys
+    assert report["trades"] == 0
+    assert report["avg_return"] == 0.0
+    assert report["pnl"] == 0.0
+    assert report["sharpe"] == 0.0
+    assert report["max_drawdown"] == 0.0
+    assert report["hit_rate"] == 0.0
+    assert report["turnover"] == 0.0
+    assert np.isnan(report["p_value"])
 
 
 def test_grid_search_selects_expected_parameters(sample_frame: pd.DataFrame) -> None:
@@ -87,6 +136,7 @@ def test_grid_search_selects_expected_parameters(sample_frame: pd.DataFrame) -> 
     assert result["params"] == {"threshold": 0.5, "slippage": 0.0}
     assert result["report"]["trades"] == 3
     assert result["report"]["avg_return"] == pytest.approx(0.1)
+    assert result["report"]["pnl"] == pytest.approx(0.3)
 
 
 def test_walk_forward_structure_and_parameter_usage(sample_frame: pd.DataFrame) -> None:
@@ -98,11 +148,16 @@ def test_walk_forward_structure_and_parameter_usage(sample_frame: pd.DataFrame) 
         slippages=[0.0, 0.05],
     )
 
-    assert result.shape == (1, 6)
+    assert result.shape == (1, 11)
     assert list(result.columns) == [
         "trades",
         "avg_return",
+        "pnl",
         "sharpe",
+        "max_drawdown",
+        "hit_rate",
+        "turnover",
+        "p_value",
         "threshold",
         "slippage",
         "start",


### PR DESCRIPTION
## Summary
- record per-period metadata during simulation so downstream reports can evaluate richer statistics
- expand the rules alpha performance report with PnL, drawdown, hit-rate, turnover, and shuffled-label significance, surfacing the fields in backtests and walk-forward runs
- adjust strategy tests to assert the extended metric set and deterministic shuffled-label p-value

## Testing
- pytest tests/fe/strategies/test_rules_alpha.py
- ruff check fe/strategies/rules_alpha.py tests/fe/strategies/test_rules_alpha.py

------
https://chatgpt.com/codex/tasks/task_e_68f6372bd1f083269d0363ae1c87cc8a