### PR TITLE
Fix maker strategy exports

### DIFF
--- a/fe/strategies/maker.py
+++ b/fe/strategies/maker.py
@@ -264,7 +264,7 @@ __all__ = [
     "Quote",
     "make_quote",
     "run_backtest",
-    "performance_metrics",
+    "pnl_metrics",
     "tune_parameters",
     "Strategy",
 ]


### PR DESCRIPTION
## Summary
- expose the existing pnl_metrics helper from fe.strategies.maker instead of the undefined performance_metrics symbol

## Testing
- pytest tests/fe/strategies/test_maker.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68f6444f28188326b6d18c22bdad3371