### PR TITLE
Rename shuffled p-value metric to p_value

### DIFF
--- a/fe/strategies/deadline_no.py
+++ b/fe/strategies/deadline_no.py
@@ -81,7 +81,7 @@ class DeadlineNoStrategy:
             "max_drawdown": float(drawdown),
             "hit_rate": hit_rate,
             "turnover": turnover,
-            "shuffled_pvalue": float(pvalue),
+            "p_value": float(pvalue),
         }
 
 

--- a/tests/fe/test_deadline_no_strategy.py
+++ b/tests/fe/test_deadline_no_strategy.py
@@ -20,9 +20,9 @@ def test_strategy_metrics():
     df = make_data()
     strat = DeadlineNoStrategy(entry_days=10, exit_days=0)
     metrics = strat.backtest(df)
-    assert set("pnl sharpe max_drawdown hit_rate turnover shuffled_pvalue".split()).issubset(metrics)
+    assert set("pnl sharpe max_drawdown hit_rate turnover p_value".split()).issubset(metrics)
     assert 0 <= metrics["hit_rate"] <= 1
-    assert 0 <= metrics["shuffled_pvalue"] <= 1
+    assert 0 <= metrics["p_value"] <= 1
 
 
 def test_walk_forward_validation():
@@ -30,7 +30,7 @@ def test_walk_forward_validation():
     param_grid = {"entry_days": [12, 10], "exit_days": [0, -1]}
     results = walk_forward_validation(df, DeadlineNoStrategy, param_grid, train_size=40, test_size=10)
     assert not results.empty
-    assert {"pnl", "sharpe", "max_drawdown", "hit_rate", "turnover", "shuffled_pvalue"}.issubset(results.columns)
+    assert {"pnl", "sharpe", "max_drawdown", "hit_rate", "turnover", "p_value"}.issubset(results.columns)
     # ensure parameters used are from grid
     assert set(results["entry_days"]).issubset({12, 10})
     assert set(results["exit_days"]).issubset({0, -1})


### PR DESCRIPTION
## Summary
- rename the DeadlineNoStrategy backtest metric key from `shuffled_pvalue` to `p_value`
- update the deadline no strategy tests to expect the new metric name

## Testing
- pytest tests/fe/strategies

------
https://chatgpt.com/codex/tasks/task_e_68f648f9062c8326a97eaf0dbc9747f1