### PR TITLE
Add sample size metrics to strategy reports

### DIFF
--- a/fe/strategies/cross_pairs.py
+++ b/fe/strategies/cross_pairs.py
@@ -260,6 +260,7 @@ def compute_backtest_metrics(
     return {
         "returns": returns,
         "cumulative": cumulative,
+        "sample_size": int(returns.shape[0]),
         "pnl": pnl,
         "sharpe": float(sharpe),
         "max_drawdown": max_drawdown,

--- a/fe/strategies/deadline_no.py
+++ b/fe/strategies/deadline_no.py
@@ -82,6 +82,7 @@ class DeadlineNoStrategy:
             "hit_rate": hit_rate,
             "turnover": turnover,
             "p_value": float(pvalue),
+            "sample_size": int(pnl.size),
         }
 
 

--- a/fe/strategies/maker.py
+++ b/fe/strategies/maker.py
@@ -149,6 +149,7 @@ def pnl_metrics(
         "hit_rate": hit_rate,
         "turnover": turnover,
         "p_value": float(p_value),
+        "sample_size": int(pnl.size),
     }
 
 

--- a/fe/strategies/rules_alpha.py
+++ b/fe/strategies/rules_alpha.py
@@ -105,6 +105,7 @@ def performance_report(
     if returns.empty:
         return {
             "trades": 0,
+            "sample_size": 0,
             "avg_return": 0.0,
             "pnl": 0.0,
             "sharpe": 0.0,
@@ -164,6 +165,7 @@ def performance_report(
 
     return {
         "trades": int(returns.size),
+        "sample_size": int(returns.size),
         "avg_return": avg,
         "pnl": pnl,
         "sharpe": sharpe,

--- a/tests/fe/strategies/test_cross_pairs.py
+++ b/tests/fe/strategies/test_cross_pairs.py
@@ -178,6 +178,7 @@ def test_compute_backtest_metrics_returns_expected_statistics():
     assert set(metrics) == {
         "returns",
         "cumulative",
+        "sample_size",
         "pnl",
         "sharpe",
         "max_drawdown",
@@ -187,6 +188,7 @@ def test_compute_backtest_metrics_returns_expected_statistics():
     }
     assert isinstance(metrics["returns"], pd.Series)
     assert isinstance(metrics["cumulative"], pd.Series)
+    assert metrics["sample_size"] == len(metrics["returns"])
 
     base_returns, base_cumulative = vectorized_backtest(
         prices, PAIR_DEFINITION, lookback=5, threshold=0.8, slippage=0.05
@@ -213,6 +215,7 @@ def test_strategy_backtest_exposes_metrics_dict():
     assert isinstance(metrics, dict)
     assert metrics["returns"].index.equals(prices.index)
     assert metrics["cumulative"].index.equals(prices.index)
+    assert metrics["sample_size"] == len(prices)
 
 
 def test_missing_columns_raise_key_error():

--- a/tests/fe/strategies/test_maker.py
+++ b/tests/fe/strategies/test_maker.py
@@ -64,6 +64,7 @@ def test_pnl_metrics_computes_expected_statistics():
     expected_drawdown = float((equity - equity.cummax()).min())
     expected_hit_rate = float((pnl > 0).mean())
     expected_turnover = float(pnl.abs().sum())
+    expected_sample_size = len(pnl)
 
     rng = np.random.default_rng(1)
     shuffled = [rng.permutation(pnl.to_numpy()).sum() for _ in range(10)]
@@ -75,6 +76,7 @@ def test_pnl_metrics_computes_expected_statistics():
     assert metrics["hit_rate"] == pytest.approx(expected_hit_rate)
     assert metrics["turnover"] == pytest.approx(expected_turnover)
     assert metrics["p_value"] == pytest.approx(expected_p_value)
+    assert metrics["sample_size"] == expected_sample_size
 
 
 def test_strategy_backtest_returns_metrics_and_series():
@@ -88,8 +90,18 @@ def test_strategy_backtest_returns_metrics_and_series():
     )
 
     assert set(
-        ["pnl", "sharpe", "max_drawdown", "hit_rate", "turnover", "p_value", "pnl_series"]
+        [
+            "pnl",
+            "sharpe",
+            "max_drawdown",
+            "hit_rate",
+            "turnover",
+            "p_value",
+            "sample_size",
+            "pnl_series",
+        ]
     ).issubset(metrics)
     assert metrics["pnl_series"].equals(expected["pnl"])
     assert isinstance(metrics["p_value"], float)
     assert 0.0 <= metrics["p_value"] <= 1.0
+    assert metrics["sample_size"] == len(expected)

--- a/tests/fe/strategies/test_rules_alpha.py
+++ b/tests/fe/strategies/test_rules_alpha.py
@@ -53,6 +53,7 @@ def test_simulate_and_performance_report(sample_frame: pd.DataFrame) -> None:
     report = performance_report(returns, permutations=permutations, seed=123)
     expected_keys = {
         "trades",
+        "sample_size",
         "avg_return",
         "pnl",
         "sharpe",
@@ -75,6 +76,7 @@ def test_simulate_and_performance_report(sample_frame: pd.DataFrame) -> None:
 
     assert report == {
         "trades": 3,
+        "sample_size": 3,
         "avg_return": pytest.approx(0.1),
         "pnl": pytest.approx(0.3),
         "sharpe": pytest.approx(np.sqrt(2)),
@@ -110,6 +112,7 @@ def test_simulate_and_report_empty_inputs() -> None:
     report = performance_report(returns)
     expected_keys = {
         "trades",
+        "sample_size",
         "avg_return",
         "pnl",
         "sharpe",
@@ -127,6 +130,7 @@ def test_simulate_and_report_empty_inputs() -> None:
     assert report["hit_rate"] == 0.0
     assert report["turnover"] == 0.0
     assert np.isnan(report["p_value"])
+    assert report["sample_size"] == 0
 
 
 def test_grid_search_selects_expected_parameters(sample_frame: pd.DataFrame) -> None:
@@ -148,9 +152,10 @@ def test_walk_forward_structure_and_parameter_usage(sample_frame: pd.DataFrame) 
         slippages=[0.0, 0.05],
     )
 
-    assert result.shape == (1, 11)
+    assert result.shape == (1, 12)
     assert list(result.columns) == [
         "trades",
+        "sample_size",
         "avg_return",
         "pnl",
         "sharpe",
@@ -166,5 +171,6 @@ def test_walk_forward_structure_and_parameter_usage(sample_frame: pd.DataFrame) 
     assert result.loc[0, "threshold"] == 0.0
     assert result.loc[0, "slippage"] == 0.0
     assert result.loc[0, "trades"] == 1
+    assert result.loc[0, "sample_size"] == 1
     assert result.loc[0, "avg_return"] == pytest.approx(0.02)
 


### PR DESCRIPTION
## Summary
- add sample_size to rule-based, cross-pair, deadline-no, and maker strategy metrics
- update research tests to expect and validate the sample_size field

## Testing
- pytest tests/fe/strategies tests/fe/signoff/test_gate.py


------
https://chatgpt.com/codex/tasks/task_e_68f8d9d961b483269f957c8be7504395