### PR TITLE
Ensure debt simulation controller formats tradeoff fallback

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -127,7 +127,7 @@ class DebtController extends Controller
                 $result['meta'] = [
                     'ranking_heuristic'       => $plan['meta']['ranking_heuristic'],
                     'ranking_reason'          => $plan['meta']['ranking_reason'] ?? $plan['meta']['ranking_heuristic'],
-                    'tradeoffs'               => $plan['meta']['tradeoffs'] ?? $plan['cost_of_deviation'],
+                    'tradeoffs'               => self::describeTradeoffs($plan),
                     'tradeoff_drivers'        => $plan['meta']['tradeoff_drivers'] ?? [],
                     'legacy_tradeoff_drivers' => $plan['meta']['legacy_tradeoff_drivers'] ?? $plan['cost_of_deviation'],
                     'heuristic_scores'        => $plan['meta']['heuristic_scores'] ?? [],
@@ -144,5 +144,63 @@ class DebtController extends Controller
             'analysis_id'      => $analysisId,
             'proposed_actions' => $proposedActions,
         ]);
+    }
+
+    /**
+     * @param array<string, mixed> $plan
+     */
+    private static function describeTradeoffs(array $plan): string
+    {
+        $tradeoffs = $plan['meta']['tradeoffs'] ?? null;
+        if (is_string($tradeoffs) && trim($tradeoffs) !== '') {
+            return $tradeoffs;
+        }
+
+        $costOfDeviation = $plan['cost_of_deviation'] ?? null;
+        if (!is_array($costOfDeviation)) {
+            return 'tradeoff impact unavailable';
+        }
+
+        $currencyValue = $costOfDeviation['currency'] ?? null;
+        $timeValue     = $costOfDeviation['time_months'] ?? null;
+
+        $hasCurrency = is_numeric($currencyValue);
+        $hasTime     = is_numeric($timeValue);
+
+        if (!$hasCurrency && !$hasTime) {
+            return 'tradeoff impact unavailable';
+        }
+
+        $currencyDescription = 'interest impact unavailable';
+        if ($hasCurrency) {
+            $currencyFloat = (float) $currencyValue;
+            if (0.0 === $currencyFloat) {
+                $currencyDescription = 'no interest impact';
+            } elseif ($currencyFloat > 0.0) {
+                $currencyDescription = sprintf('loses %s in interest savings', number_format(abs($currencyFloat), 2, '.', ''));
+            } else {
+                $currencyDescription = sprintf('saves %s more interest', number_format(abs($currencyFloat), 2, '.', ''));
+            }
+        }
+
+        $timeDescription = 'time impact unavailable';
+        if ($hasTime) {
+            $timeInteger = (int) round((float) $timeValue);
+            if (0 === $timeInteger) {
+                $timeDescription = 'no time impact';
+            } else {
+                $absMonths = abs($timeInteger);
+                $label     = 1 === $absMonths ? 'month' : 'months';
+                $timeDescription = $timeInteger > 0
+                    ? sprintf('%d extra %s', $absMonths, $label)
+                    : sprintf('%d fewer %s', $absMonths, $label);
+            }
+        }
+
+        if ('no interest impact' === $currencyDescription && 'no time impact' === $timeDescription) {
+            return 'no tradeoffs';
+        }
+
+        return sprintf('%s and %s', $currencyDescription, $timeDescription);
     }
 }

--- a/tests/unit/Api/V1/Controllers/Simulations/DebtControllerTest.php
+++ b/tests/unit/Api/V1/Controllers/Simulations/DebtControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\unit\Api\V1\Controllers\Simulations;
+
+use FireflyIII\Api\V1\Controllers\Simulations\DebtController;
+use FireflyIII\Api\V1\Requests\Simulations\DebtRequest;
+use FireflyIII\Modules\AI\Simulations\DebtSimulationService;
+use Illuminate\Http\JsonResponse;
+use Tests\integration\TestCase;
+
+final class DebtControllerTest extends TestCase
+{
+    public function testFallbackFormatsTradeoffsFromCostOfDeviation(): void
+    {
+        $service = $this->createMock(DebtSimulationService::class);
+
+        $plan = [
+            'rank'              => 2,
+            'is_optimal'        => false,
+            'strategy'          => 'snowball',
+            'accounts'          => [
+                ['account_id' => 'acc-1', 'name' => 'Debt One'],
+            ],
+            'schedule'          => [[
+                'month'           => 1,
+                'payments'        => ['acc-1' => ['amount' => 50.0]],
+                'balances'        => ['acc-1' => ['amount' => 950.0]],
+                'payments_legacy' => ['acc-1' => ['amount' => 45.0]],
+                'balances_legacy' => ['acc-1' => ['amount' => 960.0]],
+                'interest'        => 5.0,
+                'payment'         => 50.0,
+                'cash_flow'       => 20.0,
+                'unused_budget'   => 5.0,
+            ]],
+            'recommendations'          => [],
+            'legacy_recommendations'   => [],
+            'status'                   => 'active',
+            'interest_saved'           => 5.0,
+            'time_to_payoff_months'    => 12,
+            'total_interest'           => 100.0,
+            'monthly_cash_flow'        => [['month' => 1, 'cash_flow' => 20.0]],
+            'cost_of_deviation'        => ['currency' => 40.0, 'time_months' => 6],
+            'meta'                     => [
+                'ranking_heuristic'       => 'heuristic',
+                'ranking_reason'          => null,
+                'tradeoff_drivers'        => [],
+                'legacy_tradeoff_drivers' => [],
+                'heuristic_scores'        => [],
+                'strategy_explanation'    => 'explanation',
+                'accounts'                => [],
+            ],
+        ];
+
+        $service->expects(self::once())
+            ->method('simulate')
+            ->willReturn([$plan]);
+
+        $controller = new DebtController($service);
+
+        $request = $this->createMock(DebtRequest::class);
+        $request->method('getData')->willReturn([
+            'user_id'        => 'user-uuid',
+            'group_id'       => null,
+            'accounts'       => [
+                ['account_id' => 'acc-1', 'balance' => 100.0, 'apr' => 0.05, 'minimum_payment' => 20.0],
+            ],
+            'monthly_budget' => 100.0,
+            'max_options'    => 1,
+        ]);
+
+        $response = $controller($request);
+        self::assertInstanceOf(JsonResponse::class, $response);
+
+        $payload    = $response->getData(true);
+        $tradeoffs  = $payload['proposed_actions'][0]['meta']['tradeoffs'] ?? null;
+
+        self::assertIsString($tradeoffs);
+        self::assertSame('loses 40.00 in interest savings and 6 extra months', $tradeoffs);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the debt simulation controller always emits a descriptive tradeoff string by formatting the cost of deviation when metadata is absent
- add a controller-level unit test that verifies the fallback formatting when tradeoff metadata is missing

## Testing
- composer unit-test *(fails: vendor/bin/phpunit missing because dependencies are not installed)*
- composer install --no-interaction --no-progress *(fails: ext-sodium extension is unavailable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8eea5e1048326a518ca5473c75e62