### PR TITLE
Add pytest coverage for Polymarket ETL and features

### DIFF
--- a/fe/tests/__init__.py
+++ b/fe/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for finance-engine."""

--- a/fe/tests/conftest.py
+++ b/fe/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for finance-engine tests."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def sample_market() -> dict:
+    """Return a representative Polymarket market payload."""
+    return {
+        "id": "market-123",
+        "question": "Will the sample event occur?",
+        "outcomes": ["Yes", "No"],
+        "createdAt": "2024-01-01T12:00:00Z",
+        "endDate": "2024-01-07T00:00:00Z",
+        "category": "politics",
+        "resolutionDescription": "Sample resolution description.",
+        "resolutionSources": ["https://example.com/source"],
+        "events": [
+            {
+                "endDate": "2024-01-07T00:00:00Z",
+            }
+        ],
+    }

--- a/fe/tests/test_liquidity.py
+++ b/fe/tests/test_liquidity.py
@@ -1,0 +1,53 @@
+"""Tests for :mod:`fe.features.liquidity`."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from fe.features.liquidity import compute_liquidity
+
+
+def test_compute_liquidity_averages_depth() -> None:
+    """Liquidity should average bid/ask depth across snapshots within the window."""
+
+    data = pd.DataFrame(
+        [
+            {
+                "market_id": "m1",
+                "timestamp": "2024-01-10T00:00:00Z",
+                "bids": [[0.50, 10.0], [0.45, 5.0]],
+                "asks": [[0.55, 7.0]],
+            },
+            {
+                "market_id": "m1",
+                "timestamp": "2024-01-10T01:00:00Z",
+                "bids": [[0.50, 8.0]],
+                "asks": [[0.55, 6.0]],
+            },
+            {
+                "market_id": "m1",
+                "timestamp": "2024-01-09T20:00:00Z",
+                "bids": [[0.50, 20.0]],
+                "asks": [[0.55, 10.0]],
+            },
+            {
+                "market_id": "m2",
+                "timestamp": "2024-01-10T00:30:00Z",
+                "bids": [[0.40, 2.0]],
+                "asks": [[0.60, 3.0]],
+            },
+        ]
+    )
+
+    result = compute_liquidity(data, hours=2)
+
+    assert set(result.index) == {"m1", "m2"}
+    assert result.loc["m1"] == pytest.approx(9.0)
+    assert result.loc["m2"] == pytest.approx(2.5)
+
+
+def test_compute_liquidity_empty_input() -> None:
+    """An empty DataFrame should return an empty Series."""
+
+    result = compute_liquidity(pd.DataFrame())
+    assert result.empty

--- a/fe/tests/test_polymarket_etl.py
+++ b/fe/tests/test_polymarket_etl.py
@@ -1,0 +1,113 @@
+"""Tests for :mod:`fe.data.polymarket.etl`."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from fe.data.polymarket import etl
+
+
+def test_save_market_creates_partitioned_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    sample_market: dict[str, Any],
+) -> None:
+    """``save_market`` should write a single-row parquet file in the partition."""
+
+    price_payload = [
+        {"timestamp": "2024-01-05T00:00:00Z", "price": 0.42},
+        {"timestamp": "2024-01-06T00:00:00Z", "price": 0.58},
+        {"timestamp": "2024-01-06T06:00:00Z"},  # missing price ignored
+        {"t": "2024-01-06T12:00:00Z", "p": 0.61},  # alternate keys
+    ]
+    order_book_payload = {
+        "timestamp": "2024-01-05T00:00:00Z",
+        "bids": [[0.45, 120.0], [0.40, 30.0]],
+        "asks": [[0.55, 80.0]],
+    }
+    events_payload = [
+        {
+            "timestamp": "2024-01-04T00:00:00Z",
+            "event_type": "clarification",
+            "message": "Updated market rules.",
+        },
+        {"timestamp": "2024-01-05T00:00:00Z", "event_type": "clarification"},
+    ]
+
+    monkeypatch.setattr(etl, "fetch_price_history", lambda market_id: price_payload)
+    monkeypatch.setattr(etl, "fetch_order_book", lambda market_id: order_book_payload)
+    monkeypatch.setattr(
+        etl, "fetch_clarification_resolution_events", lambda market_id: events_payload
+    )
+
+    captured: dict[str, pd.DataFrame] = {}
+
+    def fake_to_parquet(self: pd.DataFrame, path: Path | str, index: bool = False) -> None:
+        captured["df"] = self.copy()
+        Path(path).write_text(self.to_json(orient="records"))
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", fake_to_parquet, raising=False)
+
+    etl.save_market(sample_market, tmp_path)
+
+    expected_dir = tmp_path / "event_date=2024-01-07" / "category=politics"
+    out_file = expected_dir / "market_market-123.parquet"
+    assert out_file.exists(), "partitioned parquet file should be created"
+
+    payload = json.loads(out_file.read_text())
+    assert len(payload) == 1
+    stored = json.loads(payload[0]["data"])
+
+    assert stored["market"]["market_id"] == "market-123"
+    # Two valid entries plus one using alternate keys should survive.
+    assert len(stored["price_history"]) == 3
+    assert stored["price_history"][0]["price"] == 0.42
+    assert stored["order_book"]["bids"] == order_book_payload["bids"]
+    assert stored["clarification_resolution_events"][0]["event_type"] == "clarification"
+
+    # Ensure the intermediate DataFrame matches expectations
+    assert "df" in captured and len(captured["df"]) == 1
+
+
+def test_fetch_price_history_handles_invalid_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid payloads should be retried and ultimately return an empty list."""
+
+    call_count = {"value": 0}
+
+    def fake_get(url: str, params: dict[str, Any] | None = None) -> dict[str, str]:
+        call_count["value"] += 1
+        return {"unexpected": "payload"}
+
+    monkeypatch.setattr(etl, "_get", fake_get)
+    monkeypatch.setattr(etl, "_sleep_with_backoff", lambda attempt: None)
+
+    result = etl.fetch_price_history("market-123")
+
+    assert result == []
+    assert call_count["value"] >= 1
+
+
+def test_assert_partitions_enforces_minimum_coverage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``assert_partitions`` should raise when coverage drops below the threshold."""
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def utcnow(cls) -> "FixedDateTime":
+            return cls(2024, 1, 10, 0, 0, 0)
+
+    monkeypatch.setattr(etl, "datetime", FixedDateTime)
+
+    for day in ("2024-01-10", "2024-01-09", "2024-01-07"):
+        market_dir = tmp_path / f"event_date={day}" / "category=politics"
+        market_dir.mkdir(parents=True, exist_ok=True)
+        (market_dir / "placeholder.txt").write_text("data")
+
+    with pytest.raises(etl.PartitionCoverageError):
+        etl.assert_partitions(tmp_path, days=5, min_coverage=0.8)

--- a/fe/tests/test_rule_objectivity.py
+++ b/fe/tests/test_rule_objectivity.py
@@ -1,0 +1,43 @@
+"""Tests for :mod:`fe.features.rule_objectivity`."""
+from __future__ import annotations
+
+from fe.features import rule_objectivity
+
+
+def test_score_rule_objectivity_clear_language() -> None:
+    """Deterministic language and numbers should mark the rule as clear."""
+
+    rule = "The official result will be determined by 3 certified sources."
+    assert rule_objectivity.score_rule_objectivity(rule) == "clear"
+
+
+def test_score_rule_objectivity_ambiguous_language() -> None:
+    """Ambiguous keywords should downgrade the score."""
+
+    rule = "Outcome may be decided at the admin's sole discretion."
+    assert rule_objectivity.score_rule_objectivity(rule) == "ambiguous"
+
+
+def test_score_rule_objectivity_unknown_language() -> None:
+    """Rules without keywords fall back to the unknown category."""
+
+    rule = "This description lacks clear qualifying language."
+    assert rule_objectivity.score_rule_objectivity(rule) == "unknown"
+
+
+def test_score_rule_objectivity_handles_missing_rule() -> None:
+    """None or empty strings should return unknown."""
+
+    assert rule_objectivity.score_rule_objectivity(None) == "unknown"
+    assert rule_objectivity.score_rule_objectivity("   ") == "unknown"
+
+
+def test_batch_score_vectorises() -> None:
+    """``batch_score`` should map :func:`score_rule_objectivity` over the inputs."""
+
+    rules = [
+        "The official statement will be published publicly.",
+        "Resolution may be adjusted by committee.",
+        None,
+    ]
+    assert rule_objectivity.batch_score(rules) == ["clear", "ambiguous", "unknown"]


### PR DESCRIPTION
## Summary
- add a shared pytest fixture with offline Polymarket market sample data
- add tests covering Polymarket ETL output partitioning, retry handling, and partition coverage checks
- add unit tests for liquidity and rule objectivity feature helpers

## Testing
- pytest fe/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f8f2d6e4d8832686c9379a0f1fd9a1