### PR TITLE
Ensure debt simulations report zero deviation cost on optimal plans

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -97,6 +97,15 @@ class DebtController extends Controller
                     $plan['schedule']
                 );
 
+                $costOfDeviation = [
+                    'currency'    => isset($plan['cost_of_deviation']['currency'])
+                        ? (float) $plan['cost_of_deviation']['currency']
+                        : 0.0,
+                    'time_months' => isset($plan['cost_of_deviation']['time_months'])
+                        ? (int) $plan['cost_of_deviation']['time_months']
+                        : 0,
+                ];
+
                 $result = [
                     'rank'       => $plan['rank'],
                     'is_optimal' => $plan['is_optimal'],
@@ -115,14 +124,8 @@ class DebtController extends Controller
                         'total_interest_paid'   => (float) $plan['total_interest'],
                         'monthly_cash_flow'     => $plan['monthly_cash_flow'],
                     ],
+                    'cost_of_deviation' => $costOfDeviation,
                 ];
-
-                if (!(bool) $plan['is_optimal']) {
-                    $result['cost_of_deviation'] = [
-                        'currency'    => (float) $plan['cost_of_deviation']['currency'],
-                        'time_months' => (int) $plan['cost_of_deviation']['time_months'],
-                    ];
-                }
 
                 $result['meta'] = [
                     'ranking_heuristic'       => $plan['meta']['ranking_heuristic'],

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -1,6 +1,7 @@
 # Debt Simulation
 
-The debt simulation endpoint evaluates multiple payoff strategies and returns ranked plans with metrics.
+The debt simulation endpoint evaluates multiple payoff strategies and returns ranked plans with metrics. Each plan now always
+includes a `cost_of_deviation` payload—even when the plan is optimal—so SDKs and clients can rely on a stable schema.
 
 ## Endpoint
 
@@ -293,6 +294,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
   - `cost_of_deviation` – Extra cost versus the optimal plan:
     - `currency` – Additional interest compared to the optimal plan.
     - `time_months` – Additional duration compared to the optimal plan in months.
+    - Optimal plans return zeros for both values so integrators can rely on a consistent object shape when checking for penalties.
   - `meta` – Additional information about the plan:
     - `strategy_explanation` – Description of how the payoff strategy works.
     - `ranking_heuristic` – Ranking algorithm applied to the plans.

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -138,12 +138,12 @@ final class DebtSimulationApiTest extends IntegrationTestCase
             self::assertIsArray($legacySchedule['balances']);
             self::assertArrayHasKey('recommendations', $action['plan']);
             self::assertArrayHasKey('legacy_recommendations', $action['plan']);
+            self::assertArrayHasKey('cost_of_deviation', $action);
+            self::assertArrayHasKey('currency', $action['cost_of_deviation']);
+            self::assertArrayHasKey('time_months', $action['cost_of_deviation']);
             if ((bool) $action['is_optimal']) {
-                self::assertArrayNotHasKey('cost_of_deviation', $action);
-            } else {
-                self::assertArrayHasKey('cost_of_deviation', $action);
-                self::assertArrayHasKey('currency', $action['cost_of_deviation']);
-                self::assertArrayHasKey('time_months', $action['cost_of_deviation']);
+                self::assertEqualsWithDelta(0.0, (float) $action['cost_of_deviation']['currency'], 0.0001);
+                self::assertEquals(0, (int) $action['cost_of_deviation']['time_months']);
             }
             self::assertArrayHasKey('ranking_reason', $action['meta']);
             self::assertIsString($action['meta']['tradeoffs']);
@@ -289,12 +289,14 @@ final class DebtSimulationApiTest extends IntegrationTestCase
         self::assertGreaterThan(1, count($actions));
 
         foreach ($actions as $action) {
-            if (!(bool) $action['is_optimal']) {
-                self::assertArrayHasKey('cost_of_deviation', $action);
-                self::assertArrayHasKey('currency', $action['cost_of_deviation']);
-                self::assertArrayHasKey('time_months', $action['cost_of_deviation']);
-                self::assertIsNumeric($action['cost_of_deviation']['currency']);
-                self::assertIsNumeric($action['cost_of_deviation']['time_months']);
+            self::assertArrayHasKey('cost_of_deviation', $action);
+            self::assertArrayHasKey('currency', $action['cost_of_deviation']);
+            self::assertArrayHasKey('time_months', $action['cost_of_deviation']);
+            self::assertIsNumeric($action['cost_of_deviation']['currency']);
+            self::assertIsNumeric($action['cost_of_deviation']['time_months']);
+            if ((bool) $action['is_optimal']) {
+                self::assertEqualsWithDelta(0.0, (float) $action['cost_of_deviation']['currency'], 0.0001);
+                self::assertEquals(0, (int) $action['cost_of_deviation']['time_months']);
             }
             self::assertArrayHasKey('heuristic_scores', $action['meta']);
             self::assertArrayHasKey('total_interest', $action['meta']['heuristic_scores']);

--- a/tests/unit/Api/V1/Controllers/Simulations/DebtControllerTest.php
+++ b/tests/unit/Api/V1/Controllers/Simulations/DebtControllerTest.php
@@ -59,16 +59,23 @@ final class DebtControllerTest extends TestCase
 
         $controller = new DebtController($service);
 
-        $request = $this->createMock(DebtRequest::class);
-        $request->method('getData')->willReturn([
-            'user_id'        => 'user-uuid',
-            'group_id'       => null,
-            'accounts'       => [
-                ['account_id' => 'acc-1', 'balance' => 100.0, 'apr' => 0.05, 'minimum_payment' => 20.0],
-            ],
-            'monthly_budget' => 100.0,
-            'max_options'    => 1,
-        ]);
+        $request = new class extends DebtRequest {
+            /**
+             * @return array<string, mixed>
+             */
+            public function getData(): array
+            {
+                return [
+                    'user_id'        => 'user-uuid',
+                    'group_id'       => null,
+                    'accounts'       => [
+                        ['account_id' => 'acc-1', 'balance' => 100.0, 'apr' => 0.05, 'minimum_payment' => 20.0],
+                    ],
+                    'monthly_budget' => 100.0,
+                    'max_options'    => 1,
+                ];
+            }
+        };
 
         $response = $controller($request);
         self::assertInstanceOf(JsonResponse::class, $response);


### PR DESCRIPTION
## Summary
- always serialize the debt simulation `cost_of_deviation` block and default optimal plans to zero penalties
- document that optimal debt strategies return zero penalty values so client schemas remain stable
- update feature and unit coverage to expect `cost_of_deviation` on optimal plans and adjust the controller unit test stub

## Testing
- vendor/bin/phpunit tests/Feature/DebtSimulationApiTest.php
- vendor/bin/phpunit tests/integration/AI/DebtSimulationEndpointTest.php
- vendor/bin/phpunit tests/unit/Api/V1/Controllers/Simulations/DebtControllerTest.php
- vendor/bin/phpunit tests/unit/DebtSimulationTest.php
- vendor/bin/phpunit tests/unit/Modules/AI/DebtSimulationServiceRankingTest.php
- vendor/bin/phpunit tests/unit/Modules/AI/MlStrategyTest.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163a8fd38c832692a8536b0148def3)