### PR TITLE
Align base rate evaluation with taxonomy horizons

### DIFF
--- a/docs/base-rate-engine.md
+++ b/docs/base-rate-engine.md
@@ -1,6 +1,6 @@
 # Base Rate Engine
 
-The base rate engine estimates outside-view probabilities using historical resolution data. It fits monotonic isotonic regression models for each category and reports calibrated probabilities with Wilson score intervals.
+The base rate engine estimates outside-view probabilities using historical resolution data. It fits monotonic isotonic regression models for each category and reports calibrated probabilities with Wilson score intervals. Historical rows are first mapped into the horizon buckets declared in `fe/base_rates/taxonomy.yaml`, ensuring that both prior estimation and Brier-score evaluations respect the taxonomy's time scopes.
 
 ## CLI
 

--- a/fe/base_rates/estimator.py
+++ b/fe/base_rates/estimator.py
@@ -23,7 +23,16 @@ import yaml
 from sklearn.isotonic import IsotonicRegression
 
 _DATA: pd.DataFrame | None = None
-_MODELS: Dict[str, Tuple[IsotonicRegression, pd.DataFrame]] = {}
+@dataclass
+class CategoryModel:
+    """Container holding the calibrated model and bucket metadata."""
+
+    model: IsotonicRegression
+    rows: pd.DataFrame
+    bucket_summary: pd.DataFrame
+
+
+_MODELS: Dict[str, CategoryModel] = {}
 _TAXONOMY: dict[str, dict] | None = None
 
 
@@ -125,17 +134,34 @@ def _bucketize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
 
 def _load_data() -> None:
     """Load historical resolution data and fit isotonic models."""
+
     global _DATA
     if _DATA is not None:
         return
+
     data_path = Path(__file__).with_name("historical.csv")
     raw = pd.read_csv(data_path)
     _load_taxonomy()
     _DATA = _bucketize_dataframe(raw)
+
     for cat, df_cat in _DATA.groupby("category"):
+        if df_cat.empty:
+            continue
+        summary = (
+            df_cat.groupby(["bucket_index", "horizon_bucket"], as_index=False)
+            .agg(successes=("outcome", "sum"), total=("outcome", "size"))
+            .sort_values("bucket_index")
+        )
+        summary["bucket_index"] = summary["bucket_index"].astype(int)
+        summary["total"] = summary["total"].astype(int)
+        rates = summary["successes"] / summary["total"]
         model = IsotonicRegression(out_of_bounds="clip")
-        model.fit(df_cat["bucket_index"], df_cat["outcome"])
-        _MODELS[cat] = (model, df_cat)
+        model.fit(
+            summary["bucket_index"],
+            rates,
+            sample_weight=summary["total"],
+        )
+        _MODELS[cat] = CategoryModel(model=model, rows=df_cat, bucket_summary=summary)
 
 
 def _wilson_interval(
@@ -182,12 +208,12 @@ def estimate_prior(
     if bucket is None:
         raise ValueError(f"no taxonomy horizon for category '{category}'")
 
-    model, df_cat = _MODELS[category]
-    prob = float(model.predict([bucket.index])[0])
+    cat_model = _MODELS[category]
+    prob = float(cat_model.model.predict([bucket.index])[0])
 
-    bucket_df = df_cat[df_cat["bucket_index"] == bucket.index]
+    bucket_df = cat_model.rows[cat_model.rows["bucket_index"] == bucket.index]
     if bucket_df.empty:
-        bucket_df = df_cat
+        bucket_df = cat_model.rows
     successes = bucket_df["outcome"].sum()
     n = len(bucket_df)
     ci = _wilson_interval(successes, n)
@@ -232,7 +258,8 @@ def evaluate_brier_score(
 
     rng = np.random.default_rng(random_state)
 
-    for _, df_cat in _DATA.groupby("category"):
+    for category, cat_model in _MODELS.items():
+        df_cat = cat_model.rows
         if len(df_cat) < 2:
             # Need at least one point for training and one for testing.
             continue
@@ -296,7 +323,8 @@ def evaluate_brier_by_taxonomy(
     results: Dict[str, Dict[str, Tuple[float, float]]] = {}
     rng = np.random.default_rng(random_state)
     taxonomy = _load_taxonomy()
-    for category, df_cat in _DATA.groupby("category"):
+    for category, cat_model in _MODELS.items():
+        df_cat = cat_model.rows
         if category not in taxonomy:
             continue
         if len(df_cat) < 2:

--- a/tests/fe/base_rates/test_estimator.py
+++ b/tests/fe/base_rates/test_estimator.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import math
+import numpy as np
 import pandas as pd
 import pytest
 import yaml
@@ -92,7 +93,7 @@ def test_taxonomy_brier_scores_cover_all_horizons(mock_taxonomy_and_historical):
     results = evaluate_brier_by_taxonomy(random_state=1)
     assert set(results) == set(taxonomy)
     for category, horizons in results.items():
-        assert set(horizons) <= set(taxonomy[category]["horizons"])
+        assert set(horizons) == set(taxonomy[category]["horizons"])
         for score, improvement in horizons.values():
             assert score >= 0
             assert math.isfinite(improvement)
@@ -114,3 +115,36 @@ def test_estimate_prior_uses_horizon_buckets(mock_taxonomy_and_historical):
     for ci in (ci_near, ci_long):
         assert len(ci) == 2 and not any(math.isnan(v) for v in ci)
         assert all(0 <= v <= 1 for v in ci)
+
+
+def test_bucket_summary_tracks_taxonomy_horizons(mock_taxonomy_and_historical):
+    taxonomy, _ = mock_taxonomy_and_historical
+    estimator._load_data()
+    geopolitics_model = estimator._MODELS["geopolitics"]
+    assert set(geopolitics_model.bucket_summary["horizon_bucket"]) == set(
+        taxonomy["geopolitics"]["horizons"].keys()
+    )
+    assert geopolitics_model.bucket_summary["total"].sum() == 12
+
+
+def test_brier_score_training_uses_bucket_indices(
+    monkeypatch, mock_taxonomy_and_historical
+):
+    taxonomy, _ = mock_taxonomy_and_historical
+    expected_indices: set[int] = set()
+    for info in taxonomy.values():
+        expected_indices.update(range(len(info["horizons"])))
+
+    seen: list[set[int]] = []
+    original_fit = estimator.IsotonicRegression.fit
+
+    def spy(self, X, y, sample_weight=None):  # type: ignore[override]
+        unique_indices = set(np.unique(np.asarray(X, dtype=int)).tolist())
+        seen.append(unique_indices)
+        return original_fit(self, X, y, sample_weight=sample_weight)
+
+    monkeypatch.setattr(estimator.IsotonicRegression, "fit", spy)
+    evaluate_brier_score(random_state=2, test_size=0.5)
+    assert seen, "expected at least one fit call"
+    for indices in seen:
+        assert indices <= expected_indices


### PR DESCRIPTION
## Summary
- bucketize historical rows into taxonomy-defined horizon buckets before fitting and capture per-bucket summaries for every category
- ensure both prior estimation and the Brier score evaluators consume the bucketized data/model metadata and document the taxonomy-driven workflow
- add regression tests that verify bucket coverage, horizon-aware scoring, and that isotonic training is performed on discrete horizon buckets

## Testing
- pytest tests/fe/base_rates -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd657790483269fea331a2172c7df)