### PR TITLE
Ensure cost of deviation is serialized for optimal plans

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -65,6 +65,10 @@ class DebtController extends Controller
         $analysisId      = (string) Str::uuid();
         $proposedActions = array_map(
             static function (array $plan): array {
+                $costOfDeviation = self::serializeCostOfDeviation($plan);
+                $planForMeta     = $plan;
+                $planForMeta['cost_of_deviation'] = $costOfDeviation;
+
                 $schedule = array_map(
                     static function (array $entry): array {
                         return [
@@ -97,15 +101,6 @@ class DebtController extends Controller
                     $plan['schedule']
                 );
 
-                $costOfDeviation = [
-                    'currency'    => isset($plan['cost_of_deviation']['currency'])
-                        ? (float) $plan['cost_of_deviation']['currency']
-                        : 0.0,
-                    'time_months' => isset($plan['cost_of_deviation']['time_months'])
-                        ? (int) $plan['cost_of_deviation']['time_months']
-                        : 0,
-                ];
-
                 $result = [
                     'rank'       => $plan['rank'],
                     'is_optimal' => $plan['is_optimal'],
@@ -130,9 +125,9 @@ class DebtController extends Controller
                 $result['meta'] = [
                     'ranking_heuristic'       => $plan['meta']['ranking_heuristic'],
                     'ranking_reason'          => $plan['meta']['ranking_reason'] ?? $plan['meta']['ranking_heuristic'],
-                    'tradeoffs'               => self::describeTradeoffs($plan),
+                    'tradeoffs'               => self::describeTradeoffs($planForMeta),
                     'tradeoff_drivers'        => $plan['meta']['tradeoff_drivers'] ?? [],
-                    'legacy_tradeoff_drivers' => $plan['meta']['legacy_tradeoff_drivers'] ?? $plan['cost_of_deviation'],
+                    'legacy_tradeoff_drivers' => $plan['meta']['legacy_tradeoff_drivers'] ?? $costOfDeviation,
                     'heuristic_scores'        => $plan['meta']['heuristic_scores'] ?? [],
                     'strategy_explanation'    => $plan['meta']['strategy_explanation'],
                     'accounts'                => $plan['meta']['accounts'] ?? ($plan['accounts'] ?? []),
@@ -147,6 +142,36 @@ class DebtController extends Controller
             'analysis_id'      => $analysisId,
             'proposed_actions' => $proposedActions,
         ]);
+    }
+
+    /**
+     * Normalize the simulation-provided cost-of-deviation structure.
+     *
+     * @param array<string, mixed> $plan
+     *
+     * @return array{currency: float, time_months: int}
+     */
+    private static function serializeCostOfDeviation(array $plan): array
+    {
+        $raw = $plan['cost_of_deviation'] ?? null;
+
+        $currency = 0.0;
+        $time     = 0;
+
+        if (is_array($raw)) {
+            if (array_key_exists('currency', $raw) && is_numeric($raw['currency'])) {
+                $currency = (float) $raw['currency'];
+            }
+
+            if (array_key_exists('time_months', $raw) && is_numeric($raw['time_months'])) {
+                $time = (int) $raw['time_months'];
+            }
+        }
+
+        return [
+            'currency'    => $currency,
+            'time_months' => $time,
+        ];
     }
 
     /**

--- a/docs/ai-extension.md
+++ b/docs/ai-extension.md
@@ -45,7 +45,7 @@ Runs heuristic strategies to generate ranked payoff plans for outstanding debts.
 - **Balanced** – Uses a smooth weighted round-robin algorithm to spread surplus payments proportionally across outstanding balances. If minimum payments exhaust the monthly budget or all debts reach zero, no additional allocations are made.
 - **ML** – Invokes an ONNX Runtime model to choose the next debt based on learned patterns. Whenever the model file is missing, fails to load, or scores stay below the configured threshold, it falls back to the avalanche heuristic.
 
-See the [Debt Simulation](debt-simulation.md) documentation—especially the [heuristics overview](debt-simulation.md#heuristics)—for request/response schemas and ranking details.
+See the [Debt Simulation](debt-simulation.md) documentation—especially the [heuristics overview](debt-simulation.md#heuristics)—for request/response schemas and ranking details. The response schema always includes `cost_of_deviation`; optimal plans simply surface zero currency and time penalties so SDK adapters do not need to branch on `is_optimal`.
 
 ### Webhooks & Event Bus
 `FinanceEventService` publishes finance events over Redis channels prefixed with `ume.events.finance.` for downstream consumers.

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -1,7 +1,8 @@
 # Debt Simulation
 
 The debt simulation endpoint evaluates multiple payoff strategies and returns ranked plans with metrics. Each plan now always
-includes a `cost_of_deviation` payload—even when the plan is optimal—so SDKs and clients can rely on a stable schema.
+includes a `cost_of_deviation` payload—even when the plan is optimal—so SDKs and clients can rely on a stable schema. Optimal
+plans simply report `0.0` currency impact and `0` extra months, clearly communicating that no penalties apply to the best option.
 
 ## Endpoint
 

--- a/tests/integration/AI/DebtSimulationEndpointTest.php
+++ b/tests/integration/AI/DebtSimulationEndpointTest.php
@@ -152,6 +152,14 @@ final class DebtSimulationEndpointTest extends TestCase
         $optimalPlans = array_values(array_filter($actions, static fn (array $action): bool => (bool) $action['is_optimal']));
         self::assertNotEmpty($optimalPlans);
 
+        foreach ($optimalPlans as $optimalPlan) {
+            self::assertArrayHasKey('cost_of_deviation', $optimalPlan);
+            self::assertArrayHasKey('currency', $optimalPlan['cost_of_deviation']);
+            self::assertArrayHasKey('time_months', $optimalPlan['cost_of_deviation']);
+            self::assertEqualsWithDelta(0.0, (float) $optimalPlan['cost_of_deviation']['currency'], 0.0001);
+            self::assertEquals(0, (int) $optimalPlan['cost_of_deviation']['time_months']);
+        }
+
         $bestPlan  = $optimalPlans[0];
         $schedule  = $bestPlan['plan']['schedule'];
         $cashFlows = $bestPlan['metrics']['monthly_cash_flow'];


### PR DESCRIPTION
## Summary
- normalize debt simulation controller output so every plan always contains a `cost_of_deviation` object, even when it is optimal, and reuse it for tradeoff metadata
- expand the debt simulation and AI extension docs to call out that optimal plans report zero penalties so SDKs can rely on the schema
- extend the integration test suite to assert that optimal API responses include zeroed `cost_of_deviation` values

## Testing
- `APP_LOG_LEVEL=error ./vendor/bin/phpunit tests/Feature/DebtSimulationApiTest.php tests/integration/AI/DebtSimulationEndpointTest.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd656ccd88326b39d5c84547ce03a)