### PR TITLE
Handle unknown cost-of-deviation values

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -149,28 +149,42 @@ class DebtController extends Controller
      *
      * @param array<string, mixed> $plan
      *
-     * @return array{currency: float, time_months: int}
+     * @return array{currency: float, time_months: int, currency_unknown: bool, time_months_unknown: bool}
      */
     private static function serializeCostOfDeviation(array $plan): array
     {
         $raw = $plan['cost_of_deviation'] ?? null;
 
-        $currency = 0.0;
-        $time     = 0;
+        $currency        = 0.0;
+        $time            = 0;
+        $currencyUnknown = true;
+        $timeUnknown     = true;
 
         if (is_array($raw)) {
             if (array_key_exists('currency', $raw) && is_numeric($raw['currency'])) {
-                $currency = (float) $raw['currency'];
+                $currency        = (float) $raw['currency'];
+                $currencyUnknown = false;
             }
 
             if (array_key_exists('time_months', $raw) && is_numeric($raw['time_months'])) {
-                $time = (int) $raw['time_months'];
+                $time        = (int) $raw['time_months'];
+                $timeUnknown = false;
+            }
+
+            if (array_key_exists('currency_unknown', $raw)) {
+                $currencyUnknown = (bool) $raw['currency_unknown'];
+            }
+
+            if (array_key_exists('time_months_unknown', $raw)) {
+                $timeUnknown = (bool) $raw['time_months_unknown'];
             }
         }
 
         return [
-            'currency'    => $currency,
-            'time_months' => $time,
+            'currency'            => $currency,
+            'time_months'         => $time,
+            'currency_unknown'    => $currencyUnknown,
+            'time_months_unknown' => $timeUnknown,
         ];
     }
 
@@ -192,8 +206,11 @@ class DebtController extends Controller
         $currencyValue = $costOfDeviation['currency'] ?? null;
         $timeValue     = $costOfDeviation['time_months'] ?? null;
 
-        $hasCurrency = is_numeric($currencyValue);
-        $hasTime     = is_numeric($timeValue);
+        $currencyUnknown = (bool) ($costOfDeviation['currency_unknown'] ?? false);
+        $timeUnknown     = (bool) ($costOfDeviation['time_months_unknown'] ?? false);
+
+        $hasCurrency = !$currencyUnknown && is_numeric($currencyValue);
+        $hasTime     = !$timeUnknown && is_numeric($timeValue);
 
         if (!$hasCurrency && !$hasTime) {
             return 'tradeoff impact unavailable';
@@ -225,7 +242,7 @@ class DebtController extends Controller
             }
         }
 
-        if ('no interest impact' === $currencyDescription && 'no time impact' === $timeDescription) {
+        if ($hasCurrency && $hasTime && 'no interest impact' === $currencyDescription && 'no time impact' === $timeDescription) {
             return 'no tradeoffs';
         }
 

--- a/docs/ai-extension.md
+++ b/docs/ai-extension.md
@@ -45,7 +45,7 @@ Runs heuristic strategies to generate ranked payoff plans for outstanding debts.
 - **Balanced** – Uses a smooth weighted round-robin algorithm to spread surplus payments proportionally across outstanding balances. If minimum payments exhaust the monthly budget or all debts reach zero, no additional allocations are made.
 - **ML** – Invokes an ONNX Runtime model to choose the next debt based on learned patterns. Whenever the model file is missing, fails to load, or scores stay below the configured threshold, it falls back to the avalanche heuristic.
 
-See the [Debt Simulation](debt-simulation.md) documentation—especially the [heuristics overview](debt-simulation.md#heuristics)—for request/response schemas and ranking details. The response schema always includes `cost_of_deviation`; optimal plans simply surface zero currency and time penalties so SDK adapters do not need to branch on `is_optimal`.
+See the [Debt Simulation](debt-simulation.md) documentation—especially the [heuristics overview](debt-simulation.md#heuristics)—for request/response schemas and ranking details. The response schema always includes `cost_of_deviation` with explicit `*_unknown` flags so SDK adapters can distinguish unavailable metrics from true zero penalties without branching on `is_optimal`.
 
 ### Webhooks & Event Bus
 `FinanceEventService` publishes finance events over Redis channels prefixed with `ume.events.finance.` for downstream consumers.

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -139,7 +139,9 @@ Simulation results are cached per user to speed up repeated requests. The cache 
       },
       "cost_of_deviation": {
         "currency": 0,
-        "time_months": 0
+        "time_months": 0,
+        "currency_unknown": false,
+        "time_months_unknown": false
       },
       "meta": {
         "ranking_heuristic": "interest_then_months",
@@ -242,7 +244,9 @@ Simulation results are cached per user to speed up repeated requests. The cache 
       },
       "cost_of_deviation": {
         "currency": 61.88,
-        "time_months": 2
+        "time_months": 2,
+        "currency_unknown": false,
+        "time_months_unknown": false
       },
       "meta": {
         "ranking_heuristic": "interest_then_months",
@@ -295,7 +299,8 @@ Simulation results are cached per user to speed up repeated requests. The cache 
   - `cost_of_deviation` – Extra cost versus the optimal plan:
     - `currency` – Additional interest compared to the optimal plan.
     - `time_months` – Additional duration compared to the optimal plan in months.
-    - Optimal plans return zeros for both values so integrators can rely on a consistent object shape when checking for penalties.
+    - `currency_unknown` / `time_months_unknown` – Flags indicating whether each penalty is unavailable from the originating strategy. When `true`, treat the value as unknown rather than a zero-impact default.
+    - Optimal plans return zeros for both values with `*_unknown` fields set to `false` so integrators can rely on a consistent object shape when checking for penalties.
   - `meta` – Additional information about the plan:
     - `strategy_explanation` – Description of how the payoff strategy works.
     - `ranking_heuristic` – Ranking algorithm applied to the plans.

--- a/tests/unit/Api/V1/Controllers/Simulations/DebtControllerTest.php
+++ b/tests/unit/Api/V1/Controllers/Simulations/DebtControllerTest.php
@@ -86,4 +86,80 @@ final class DebtControllerTest extends TestCase
         self::assertIsString($tradeoffs);
         self::assertSame('loses 40.00 in interest savings and 6 extra months', $tradeoffs);
     }
+
+    public function testMissingDeviationDataIsMarkedUnknown(): void
+    {
+        $service = $this->createMock(DebtSimulationService::class);
+
+        $plan = [
+            'rank'                     => 1,
+            'is_optimal'               => true,
+            'strategy'                 => 'balanced',
+            'accounts'                 => [
+                ['account_id' => 'acc-1', 'name' => 'Debt One'],
+            ],
+            'schedule'                 => [[
+                'month'           => 1,
+                'payments'        => ['acc-1' => ['amount' => 50.0]],
+                'balances'        => ['acc-1' => ['amount' => 950.0]],
+                'payments_legacy' => ['acc-1' => ['amount' => 45.0]],
+                'balances_legacy' => ['acc-1' => ['amount' => 960.0]],
+                'interest'        => 5.0,
+                'payment'         => 50.0,
+                'cash_flow'       => 20.0,
+                'unused_budget'   => 5.0,
+            ]],
+            'recommendations'          => [],
+            'legacy_recommendations'   => [],
+            'status'                   => 'active',
+            'interest_saved'           => 5.0,
+            'time_to_payoff_months'    => 12,
+            'total_interest'           => 100.0,
+            'monthly_cash_flow'        => [['month' => 1, 'cash_flow' => 20.0]],
+            'meta'                     => [
+                'ranking_heuristic'       => 'heuristic',
+                'ranking_reason'          => null,
+                'tradeoff_drivers'        => [],
+                'legacy_tradeoff_drivers' => [],
+                'heuristic_scores'        => [],
+                'strategy_explanation'    => 'explanation',
+                'accounts'                => [],
+            ],
+        ];
+
+        $service->expects(self::once())
+            ->method('simulate')
+            ->willReturn([$plan]);
+
+        $controller = new DebtController($service);
+
+        $request = new class extends DebtRequest {
+            /**
+             * @return array<string, mixed>
+             */
+            public function getData(): array
+            {
+                return [
+                    'user_id'        => 'user-uuid',
+                    'group_id'       => null,
+                    'accounts'       => [
+                        ['account_id' => 'acc-1', 'balance' => 100.0, 'apr' => 0.05, 'minimum_payment' => 20.0],
+                    ],
+                    'monthly_budget' => 100.0,
+                    'max_options'    => 1,
+                ];
+            }
+        };
+
+        $response = $controller($request);
+
+        $payload    = $response->getData(true);
+        $action     = $payload['proposed_actions'][0];
+        $costOfDev  = $action['cost_of_deviation'];
+        $tradeoffs  = $action['meta']['tradeoffs'];
+
+        self::assertTrue($costOfDev['currency_unknown']);
+        self::assertTrue($costOfDev['time_months_unknown']);
+        self::assertSame('tradeoff impact unavailable', $tradeoffs);
+    }
 }


### PR DESCRIPTION
## Summary
- include explicit unknown flags when serializing debt deviation costs
- adjust tradeoff descriptions to surface unavailable penalties instead of zero defaults
- document the updated schema and add coverage for missing deviation data

## Testing
- phpunit --filter DebtControllerTest *(fails: phpunit not installed in PATH)*
- ./vendor/bin/phpunit --filter DebtControllerTest *(fails: binary missing prior to dependency install)*
- composer install --no-interaction --no-progress *(fails: PHP ext-sodium missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693829a1921c83268154549147bc2d9f)