### PR TITLE
Add heuristic drivers to debt simulations

### DIFF
--- a/app/Api/V1/Controllers/Simulations/DebtController.php
+++ b/app/Api/V1/Controllers/Simulations/DebtController.php
@@ -81,6 +81,7 @@ class DebtController extends Controller
                             'payment'         => $entry['payment'],
                             'cash_flow'       => $entry['cash_flow'],
                             'unused_budget'   => $entry['unused_budget'],
+                            'annotations'     => $entry['annotations'] ?? [],
                         ];
                     },
                     $plan['schedule']
@@ -107,6 +108,7 @@ class DebtController extends Controller
                     'plan'       => [
                         'strategy'               => $plan['strategy'],
                         'accounts'               => $plan['accounts'] ?? [],
+                        'account_drivers'        => $plan['account_drivers'] ?? [],
                         'schedule'               => $schedule,
                         'legacy_schedule'        => $legacySchedule,
                         'recommendations'        => $plan['recommendations'] ?? [],
@@ -131,6 +133,7 @@ class DebtController extends Controller
                     'heuristic_scores'        => $plan['meta']['heuristic_scores'] ?? [],
                     'strategy_explanation'    => $plan['meta']['strategy_explanation'],
                     'accounts'                => $plan['meta']['accounts'] ?? ($plan['accounts'] ?? []),
+                    'account_drivers'         => $plan['meta']['account_drivers'] ?? ($plan['account_drivers'] ?? []),
                 ];
 
                 return $result;

--- a/app/Modules/AI/Simulations/DebtSimulationService.php
+++ b/app/Modules/AI/Simulations/DebtSimulationService.php
@@ -223,7 +223,7 @@ class DebtSimulationService
                         'time_months' => $plan['months'] - $bestMonths,
                     ];
 
-                    $currencyDeviation = (float) $plan['cost_of_deviation']['currency'];
+                    $currencyDeviation = $plan['cost_of_deviation']['currency'];
                     $monthsDeviation   = (int) $plan['cost_of_deviation']['time_months'];
 
                     if ($plan['is_optimal']) {
@@ -266,7 +266,7 @@ class DebtSimulationService
                         'currency'    => [
                             'account_id'   => null,
                             'display_name' => 'Interest delta',
-                            'value'        => (float) $plan['cost_of_deviation']['currency'],
+                            'value'        => $plan['cost_of_deviation']['currency'],
                         ],
                         'time_months' => [
                             'account_id'   => null,
@@ -285,6 +285,7 @@ class DebtSimulationService
                             'ranking_reason'          => $rankingReason,
                             'tradeoffs'               => $tradeoffString,
                             'accounts'                => $plan['accounts'] ?? [],
+                            'account_drivers'         => $plan['account_drivers'] ?? [],
                         ]
                     );
 
@@ -332,10 +333,34 @@ class DebtSimulationService
         $accountsIndex      = [];
         $recommendations    = [];
         $legacyRecommendations = [];
+        $accountDrivers     = [];
+        $priorityContext    = $this->describeStrategyDrivers($strategy);
         foreach ($debts as $debt) {
             $accountsIndex[$debt['account_id']] = [
                 'account_id'   => $debt['account_id'],
                 'display_name' => $debt['display_name'],
+            ];
+
+            $accountDrivers[$debt['account_id']] = [
+                'account_id'    => $debt['account_id'],
+                'display_name'  => $debt['display_name'],
+                'drivers'       => [
+                    'apr' => [
+                        'display_name' => 'APR priority',
+                        'value'        => $debt['rate'],
+                        'reason'       => $priorityContext['apr'],
+                    ],
+                    'balance' => [
+                        'display_name' => 'Balance priority',
+                        'value'        => $debt['balance'],
+                        'reason'       => $priorityContext['balance'],
+                    ],
+                    'minimum_payment' => [
+                        'display_name' => 'Minimum payment',
+                        'value'        => $debt['min_payment'],
+                        'reason'       => 'Minimum payments are made before targeting extra payments.',
+                    ],
+                ],
             ];
 
             if ($debt['rate'] >= self::HIGH_APR_THRESHOLD) {
@@ -389,6 +414,7 @@ class DebtSimulationService
             $paymentPlan        = [];
             $legacyPaymentPlan  = [];
             $remainingBudget = $monthlyBudget;
+            $annotations     = [];
 
             // Pay minimums first.
             foreach ($debts as &$debt) {
@@ -443,10 +469,18 @@ class DebtSimulationService
                 $paymentPlan[$accountId]['amount'] += $extra;
                 $legacyPaymentPlan[$displayName]     = ($legacyPaymentPlan[$displayName] ?? 0.0) + $extra;
                 $remainingBudget            -= $extra;
+
+                $annotations[] = [
+                    'type'         => 'target_selection',
+                    'account_id'   => $accountId,
+                    'display_name' => $displayName,
+                    'reason'       => $priorityContext['selection'],
+                    'drivers'      => $accountDrivers[$accountId]['drivers'] ?? [],
+                ];
                 unset($target);
             }
 
-            $totalPayment    = array_sum(array_map(static fn (array $entry): float => (float) $entry['amount'], $paymentPlan));
+            $totalPayment    = array_sum(array_map(static fn (array $entry): float => $entry['amount'], $paymentPlan));
             $unusedBudget    = max($remainingBudget, 0.0);
             $totalInterest  += $interestThisMonth;
             $cashFlowTimeline[] = [
@@ -479,6 +513,7 @@ class DebtSimulationService
                 'payment'       => $totalPayment,
                 'cash_flow'     => $totalPayment,
                 'unused_budget' => $unusedBudget,
+                'annotations'   => $annotations,
             ];
 
             if ($balanceAfter > $balanceBefore) {
@@ -489,6 +524,7 @@ class DebtSimulationService
 
         return [
             'accounts'          => array_values($accountsIndex),
+            'account_drivers'   => array_values($accountDrivers),
             'schedule'          => $schedule,
             'total_interest'    => $totalInterest,
             'months'            => $month,
@@ -511,6 +547,44 @@ class DebtSimulationService
         }
 
         return false;
+    }
+
+    /**
+     * Provide human-friendly context for how a strategy chooses targets.
+     *
+     * @return array{apr: string, balance: string, selection: string}
+     */
+    private function describeStrategyDrivers(StrategyInterface $strategy): array
+    {
+        $name = $strategy->getName();
+
+        return match ($name) {
+            'avalanche' => [
+                'apr'       => 'Extra payments focus on the highest APR first to cut interest costs.',
+                'balance'   => 'Balances are considered after APR when selecting targets.',
+                'selection' => 'Chosen because this debt currently has the highest APR.',
+            ],
+            'snowball' => [
+                'apr'       => 'APR is secondary; smallest balances are targeted to gain quick wins.',
+                'balance'   => 'Extra payments prioritize the smallest balance to clear debts quickly.',
+                'selection' => 'Chosen because this debt has one of the smallest remaining balances.',
+            ],
+            'balanced' => [
+                'apr'       => 'APR does not change the proportional distribution but higher APR still accrues more interest.',
+                'balance'   => 'Extra payments are distributed proportionally to each remaining balance.',
+                'selection' => 'Chosen as part of proportional balance-based distribution.',
+            ],
+            'ml' => [
+                'apr'       => 'APR informs the model and the fallback avalanche ordering.',
+                'balance'   => 'Balances inform the model and fallback ordering when predictions are unavailable.',
+                'selection' => 'Chosen based on the machine learning ranking or avalanche fallback.',
+            ],
+            default => [
+                'apr'       => 'APR influences overall interest but may not directly control targeting.',
+                'balance'   => 'Balances inform how remaining debts are prioritized.',
+                'selection' => 'Chosen according to the strategy targeting rules.',
+            ],
+        };
     }
 
 }

--- a/docs/debt-simulation.md
+++ b/docs/debt-simulation.md
@@ -160,6 +160,17 @@ Simulation results are cached per user to speed up repeated requests. The cache 
           "currency": 0,
           "time_months": 0
         },
+        "account_drivers": [
+          {
+            "account_id": "af13c6c4-1d05-4d26-8b16-ef3d988c1f02",
+            "display_name": "Loan 1",
+            "drivers": {
+              "apr": {"display_name": "APR priority", "value": 0.1, "reason": "Extra payments focus on the highest APR first to cut interest costs."},
+              "balance": {"display_name": "Balance priority", "value": 5000, "reason": "Balances are considered after APR when selecting targets."},
+              "minimum_payment": {"display_name": "Minimum payment", "value": 50, "reason": "Minimum payments are made before targeting extra payments."}
+            }
+          }
+        ],
         "accounts": [
           {"account_id": "af13c6c4-1d05-4d26-8b16-ef3d988c1f02", "display_name": "Loan 1"},
           {"account_id": "b2a1a148-9b91-455c-8964-fba303b3f7ca", "display_name": "Loan 2"}
@@ -202,6 +213,15 @@ Simulation results are cached per user to speed up repeated requests. The cache 
                 "balance": 1175
               }
             },
+            "annotations": [
+              {
+                "type": "target_selection",
+                "account_id": "af13c6c4-1d05-4d26-8b16-ef3d988c1f02",
+                "display_name": "Loan 1",
+                "reason": "Chosen because this debt currently has the highest APR.",
+                "drivers": {"apr": {"display_name": "APR priority", "value": 0.1, "reason": "Extra payments focus on the highest APR first to cut interest costs."}}
+              }
+            ],
             "payments_legacy": {"Loan 1": 475, "Loan 2": 25},
             "balances_legacy": {"Loan 1": 4025, "Loan 2": 1175},
             "interest": 57.19,
@@ -283,7 +303,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
   - `plan` – Detailed strategy output:
     - `strategy` – Name of the heuristic applied (`avalanche`, `snowball`, `balanced`, or `ml`).
     - `accounts` – Metadata for each simulated account, exposing both the `account_id` (UUID) and the `display_name` used in the human-readable output.
-    - `schedule` – Monthly breakdown keyed by account UUID. Each entry contains both structured `payments`/`balances` objects and `payments_legacy`/`balances_legacy` maps for backward compatibility.
+    - `schedule` – Monthly breakdown keyed by account UUID. Each entry contains both structured `payments`/`balances` objects and `payments_legacy`/`balances_legacy` maps for backward compatibility, plus `annotations` describing why extra payments were directed to specific debts.
     - `legacy_schedule` – A historical view of the schedule using the previous name-keyed representation.
     - `recommendations` – Associative array keyed by account UUID that includes the refinance message and the display name.
     - `legacy_recommendations` – Array of refinance suggestions in the legacy string-only format.
@@ -304,6 +324,7 @@ Simulation results are cached per user to speed up repeated requests. The cache 
     - `tradeoff_drivers` – Structured representation of the cost-of-deviation values, including descriptive labels and optional `account_id` references.
     - `legacy_tradeoff_drivers` – Flat representation matching the previous response contract.
     - `accounts` – Plan-level account metadata mirrored from the schedule to simplify client access.
+    - `account_drivers` – Per-account heuristic drivers explaining how APR, balance, and minimum payments influenced targeting.
 
 ## Heuristics
 

--- a/tests/Feature/DebtSimulationApiTest.php
+++ b/tests/Feature/DebtSimulationApiTest.php
@@ -116,7 +116,7 @@ final class DebtSimulationApiTest extends IntegrationTestCase
                         'total_interest_paid',
                         'monthly_cash_flow',
                     ],
-                    'meta' => ['ranking_heuristic', 'tradeoffs', 'ranking_reason', 'strategy_explanation', 'tradeoff_drivers', 'legacy_tradeoff_drivers', 'accounts'],
+                'meta' => ['ranking_heuristic', 'tradeoffs', 'ranking_reason', 'strategy_explanation', 'tradeoff_drivers', 'legacy_tradeoff_drivers', 'accounts', 'account_drivers'],
                 ],
             ],
         ]);

--- a/tests/api/v1/Simulations/DebtSimulationTest.php
+++ b/tests/api/v1/Simulations/DebtSimulationTest.php
@@ -190,7 +190,7 @@ final class DebtSimulationTest extends TestCase
                         'total_interest_paid',
                         'monthly_cash_flow',
                     ],
-                    'meta' => ['ranking_heuristic', 'tradeoffs', 'ranking_reason', 'strategy_explanation', 'tradeoff_drivers', 'legacy_tradeoff_drivers', 'accounts'],
+                    'meta' => ['ranking_heuristic', 'tradeoffs', 'ranking_reason', 'strategy_explanation', 'tradeoff_drivers', 'legacy_tradeoff_drivers', 'accounts', 'account_drivers'],
                 ],
             ],
         ]);

--- a/tests/feature/Api/V1/Simulations/DebtControllerTest.php
+++ b/tests/feature/Api/V1/Simulations/DebtControllerTest.php
@@ -105,17 +105,18 @@ final class DebtControllerTest extends TestCase
                     'total_interest_paid',
                     'monthly_cash_flow',
                 ],
-                'meta' => [
-                    'ranking_heuristic',
-                    'tradeoffs',
-                    'tradeoff_drivers',
-                    'legacy_tradeoff_drivers',
-                    'heuristic_scores',
-                    'strategy_explanation',
-                    'ranking_reason',
-                    'accounts',
-                ],
-            ]],
+                    'meta' => [
+                        'ranking_heuristic',
+                        'tradeoffs',
+                        'tradeoff_drivers',
+                        'legacy_tradeoff_drivers',
+                        'heuristic_scores',
+                        'strategy_explanation',
+                        'ranking_reason',
+                        'accounts',
+                        'account_drivers',
+                    ],
+                ]],
         ]);
 
         self::assertTrue(Str::isUuid($response->json('analysis_id')));
@@ -126,6 +127,7 @@ final class DebtControllerTest extends TestCase
         self::assertTrue((bool) $action['is_optimal']);
         self::assertIsArray($action['plan']['schedule']);
         self::assertNotEmpty($action['plan']['schedule']);
+        self::assertArrayHasKey('annotations', $action['plan']['schedule'][0]);
         self::assertIsArray($action['plan']['legacy_schedule']);
         self::assertSameSize($action['plan']['schedule'], $action['plan']['legacy_schedule']);
         self::assertIsString($action['plan']['status']);
@@ -133,6 +135,7 @@ final class DebtControllerTest extends TestCase
         self::assertIsArray($action['meta']['tradeoff_drivers']);
         self::assertIsArray($action['meta']['legacy_tradeoff_drivers']);
         self::assertIsArray($action['meta']['accounts']);
+        self::assertIsArray($action['meta']['account_drivers']);
         self::assertIsString($action['meta']['tradeoffs']);
     }
 

--- a/tests/unit/Modules/AI/DebtSimulationServiceMetaTest.php
+++ b/tests/unit/Modules/AI/DebtSimulationServiceMetaTest.php
@@ -35,6 +35,7 @@ final class DebtSimulationServiceMetaTest extends TestCase
             self::assertArrayHasKey('strategy_explanation', $plan['meta']);
             self::assertArrayHasKey('legacy_tradeoff_drivers', $plan['meta']);
             self::assertArrayHasKey('accounts', $plan['meta']);
+            self::assertArrayHasKey('account_drivers', $plan['meta']);
 
             self::assertIsArray($plan['meta']['tradeoff_drivers']);
             self::assertArrayHasKey('currency', $plan['meta']['tradeoff_drivers']);
@@ -44,6 +45,8 @@ final class DebtSimulationServiceMetaTest extends TestCase
             self::assertArrayHasKey('value', $plan['meta']['tradeoff_drivers']['time_months']);
             self::assertArrayHasKey('display_name', $plan['meta']['tradeoff_drivers']['time_months']);
             self::assertIsString($plan['meta']['strategy_explanation']);
+            self::assertIsArray($plan['meta']['account_drivers']);
+            self::assertNotEmpty($plan['schedule'][0]['annotations'] ?? []);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add per-account heuristic driver metadata and step annotations to debt simulation schedules
- surface new metadata through the debt controller and document the updated response contract
- extend tests to cover the additional schedule annotations and account driver payloads

## Testing
- `vendor/bin/phpunit --filter DebtSimulationServiceMetaTest`
- `vendor/bin/phpunit --filter DebtControllerTest`
- `APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= vendor/bin/phpstan analyse app/Modules/AI/Simulations app/Api/V1/Controllers/Simulations --no-progress --memory-limit=512M`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693829a0c6cc83268f2ab19b2d2b7dc1)