### PR TITLE
Add scheduled Polymarket ETL workflow

### DIFF
--- a/.github/workflows/polymarket-etl.yml
+++ b/.github/workflows/polymarket-etl.yml
@@ -1,0 +1,73 @@
+name: Polymarket ETL
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      coverage_days:
+        description: "Trailing days used for coverage validation"
+        required: false
+        default: "30"
+      min_coverage:
+        description: "Minimum acceptable coverage fraction"
+        required: false
+        default: "0.9"
+      output_dir:
+        description: "Output directory for partitioned parquet"
+        required: false
+        default: "data/polymarket"
+      log_dir:
+        description: "Log directory"
+        required: false
+        default: ""
+      log_retention_days:
+        description: "Days to retain ETL log files"
+        required: false
+        default: "14"
+      artifact_retention_days:
+        description: "Days to retain uploaded ETL artifacts"
+        required: false
+        default: "14"
+
+jobs:
+  run-etl:
+    name: Run Polymarket ETL
+    runs-on: ubuntu-latest
+    env:
+      POLYMARKET_OUTPUT_DIR: ${{ github.event.inputs.output_dir || 'data/polymarket' }}
+      POLYMARKET_LOG_DIR: ${{ github.event.inputs.log_dir || format('{0}/logs', github.event.inputs.output_dir || 'data/polymarket') }}
+      POLYMARKET_COVERAGE_DAYS: ${{ github.event.inputs.coverage_days || '30' }}
+      POLYMARKET_MIN_COVERAGE: ${{ github.event.inputs.min_coverage || '0.9' }}
+      POLYMARKET_LOG_RETENTION_DAYS: ${{ github.event.inputs.log_retention_days || '14' }}
+      POLYMARKET_ARTIFACT_RETENTION_DAYS: ${{ github.event.inputs.artifact_retention_days || '14' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ETL dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pandas requests pyarrow pydantic
+      - name: Run daily Polymarket ETL
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m fe.data.polymarket.etl \
+            --output-dir "${POLYMARKET_OUTPUT_DIR}" \
+            --days "${POLYMARKET_COVERAGE_DAYS}" \
+            --min-coverage "${POLYMARKET_MIN_COVERAGE}" \
+            --log-dir "${POLYMARKET_LOG_DIR}" \
+            --log-retention-days "${POLYMARKET_LOG_RETENTION_DAYS}" \
+            --log-level INFO
+      - name: Upload ETL artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: polymarket-etl-output
+          path: |
+            ${{ env.POLYMARKET_OUTPUT_DIR }}
+            ${{ env.POLYMARKET_LOG_DIR }}
+          retention-days: ${{ env.POLYMARKET_ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: warn

--- a/docs/polymarket-etl.md
+++ b/docs/polymarket-etl.md
@@ -1,0 +1,37 @@
+# Polymarket ETL operations
+
+This repository includes a scheduled job that runs the Polymarket ETL daily so the partition coverage window remains healthy.
+
+## Schedule and workflow
+
+- Workflow: `.github/workflows/polymarket-etl.yml`
+- Schedule: daily at 06:00 UTC via cron plus manual `workflow_dispatch` for reruns.
+- Failure criteria: the ETL raises `PartitionCoverageError` when `assert_partitions` detects coverage below the configured window and the workflow fails.
+
+## Configuration
+
+Environment variables drive where data and logs are stored and how long to keep them:
+
+- `POLYMARKET_OUTPUT_DIR`: destination for partitioned Parquet files. Defaults to `data/polymarket` in the repository.
+- `POLYMARKET_LOG_DIR`: folder for run logs. Defaults to `<output_dir>/logs`.
+- `POLYMARKET_LOG_RETENTION_DAYS`: how many days of log files to keep (set to `0` to disable pruning).
+- `POLYMARKET_COVERAGE_DAYS`: trailing days window passed to `assert_partitions`.
+- `POLYMARKET_MIN_COVERAGE`: minimum acceptable fraction of days present in the window.
+- `POLYMARKET_ARTIFACT_RETENTION_DAYS`: how many days to keep uploaded artifacts on GitHub.
+
+These values can be adjusted per-run through workflow inputs or environment overrides.
+
+## Rerun procedures
+
+1. Navigate to **Actions → Polymarket ETL** in GitHub and select **Run workflow** to trigger a manual run with custom configuration values if needed.
+2. Inspect the uploaded artifacts (`polymarket-etl-output`) for the Parquet partitions and ETL logs. Logs are also stored under `POLYMARKET_LOG_DIR` in the runner and pruned according to `POLYMARKET_LOG_RETENTION_DAYS`.
+3. If a run fails because of insufficient partition coverage, rerun with a longer `POLYMARKET_COVERAGE_DAYS` window and verify missing dates are backfilled, or reprocess locally using:
+   ```bash
+   python -m fe.data.polymarket.etl --output-dir <path> --days <window> --min-coverage <threshold> \
+     --log-dir <log_path> --log-retention-days <days>
+   ```
+   After a successful local run, upload the refreshed partitions and re-trigger the workflow to confirm coverage.
+
+## Outputs and artifacts
+
+Each workflow run uploads the Parquet output directory and ETL log directory as artifacts with configurable retention. Logs are timestamped per run to help correlate coverage errors with the underlying API responses.

--- a/fe/data/polymarket/etl.py
+++ b/fe/data/polymarket/etl.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import logging
+import os
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar
 
 import pandas as pd
 import requests
@@ -303,6 +303,8 @@ def save_market(
                 category=category,
             )
             order_book = ob_model.model_dump()
+            order_book["bids"] = [list(level) for level in order_book.get("bids", [])]
+            order_book["asks"] = [list(level) for level in order_book.get("asks", [])]
         except Exception:
             order_book = None
 
@@ -392,30 +394,145 @@ def assert_partitions(
         )
 
 
-def main(output_dir: Optional[Path] = None, days: int = 365) -> None:
+def _configure_logging(
+    log_dir: Optional[Path], level: str = "INFO"
+) -> tuple[Optional[Path], logging.Logger]:
+    level_name = level.upper()
+    log_level = getattr(logging, level_name, logging.INFO)
+
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    log_path = None
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / f"polymarket_etl_{datetime.utcnow():%Y%m%dT%H%M%SZ}.log"
+        handlers.append(logging.FileHandler(log_path))
+
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=handlers,
+    )
+    logger = logging.getLogger(__name__)
+    return log_path, logger
+
+
+def prune_logs(log_dir: Path, retention_days: int) -> Sequence[Path]:
+    """Delete log files older than ``retention_days``.
+
+    Parameters
+    ----------
+    log_dir:
+        Directory containing log files.
+    retention_days:
+        Files older than this many days will be removed. Values <= 0
+        disable pruning.
+    """
+
+    if retention_days <= 0 or not log_dir.exists():
+        return []
+
+    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+    removed: list[Path] = []
+
+    for log_file in log_dir.glob("*.log"):
+        try:
+            modified = datetime.utcfromtimestamp(log_file.stat().st_mtime)
+        except OSError:
+            continue
+        if modified < cutoff:
+            try:
+                log_file.unlink()
+                removed.append(log_file)
+            except OSError:
+                logger.warning("Failed to delete old log %s", log_file)
+    return removed
+
+
+def main(
+    output_dir: Optional[Path] = None,
+    days: int = 365,
+    min_coverage: float = 0.9,
+    log_dir: Optional[Path] = None,
+    log_retention_days: int = 14,
+    log_level: str = "INFO",
+) -> None:
+    output_path = output_dir or _DEFAULT_OUTPUT_DIR
+    resolved_log_dir = log_dir or Path(
+        os.environ.get("POLYMARKET_LOG_DIR", output_path / "logs")
+    )
+
+    log_path, configured_logger = _configure_logging(resolved_log_dir, log_level)
+    if log_path:
+        configured_logger.info("Logging ETL run to %s", log_path)
+
+    removed_logs = prune_logs(resolved_log_dir, log_retention_days)
+    if removed_logs:
+        configured_logger.info(
+            "Pruned %s old log file(s) older than %s days",
+            len(removed_logs),
+            log_retention_days,
+        )
+
     markets = get_resolved_markets(days)
+    configured_logger.info("Fetched %s resolved market(s)", len(markets))
     for market in markets:
-        save_market(market, output_dir)
-    assert_partitions(output_dir or _DEFAULT_OUTPUT_DIR, days)
+        save_market(market, output_path)
+    assert_partitions(output_path, days, min_coverage)
 
 
-def cli() -> None:
-    parser = argparse.ArgumentParser(description="Polymarket ETL")
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the Polymarket ETL")
     parser.add_argument(
         "--output-dir",
         type=Path,
         default=None,
-        help="Directory for output parquet files",
+        help="Where to write partitioned parquet files (defaults to POLYMARKET_OUTPUT_DIR)",
     )
     parser.add_argument(
         "--days",
         type=int,
         default=365,
-        help="Number of days of resolved markets to process",
+        help="Number of trailing days to download and validate",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--min-coverage",
+        type=float,
+        default=0.9,
+        help="Minimum acceptable partition coverage for the validation window",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=None,
+        help="Directory for ETL log files (defaults to POLYMARKET_LOG_DIR or <output>/logs)",
+    )
+    parser.add_argument(
+        "--log-retention-days",
+        type=int,
+        default=14,
+        help="Prune log files older than this many days; set to 0 to disable",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ERROR)",
+    )
+    return parser.parse_args(argv)
+
+
+def cli() -> None:
+    args = _parse_args()
     try:
-        main(args.output_dir, args.days)
+        main(
+            output_dir=args.output_dir,
+            days=args.days,
+            min_coverage=args.min_coverage,
+            log_dir=args.log_dir,
+            log_retention_days=args.log_retention_days,
+            log_level=args.log_level,
+        )
     except PartitionCoverageError as exc:
         logger.error("%s", exc)
         raise SystemExit(1) from exc

--- a/fe/tests/test_polymarket_etl.py
+++ b/fe/tests/test_polymarket_etl.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -111,3 +112,19 @@ def test_assert_partitions_enforces_minimum_coverage(
 
     with pytest.raises(etl.PartitionCoverageError):
         etl.assert_partitions(tmp_path, days=5, min_coverage=0.8)
+
+
+def test_prune_logs_respects_retention(tmp_path: Path) -> None:
+    old_log = tmp_path / "run1.log"
+    fresh_log = tmp_path / "run2.log"
+    old_log.write_text("old")
+    fresh_log.write_text("fresh")
+
+    cutoff = datetime.utcnow().timestamp() - (5 * 86400)
+    os.utime(old_log, (cutoff, cutoff))
+
+    removed = etl.prune_logs(tmp_path, retention_days=3)
+
+    assert old_log in removed
+    assert fresh_log.exists()
+    assert fresh_log not in removed

--- a/tests/fe/strategies/test_maker.py
+++ b/tests/fe/strategies/test_maker.py
@@ -7,7 +7,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
-from fe.strategies.maker import Strategy, make_quote, pnl_metrics, run_backtest
+from fe.strategies.maker import Strategy, make_quote, pnl_metrics, run_backtest  # noqa: E402
 
 
 def test_extreme_liquidity_quote_is_not_inverted():

--- a/tests/fe/strategies/test_rules_alpha.py
+++ b/tests/fe/strategies/test_rules_alpha.py
@@ -173,4 +173,3 @@ def test_walk_forward_structure_and_parameter_usage(sample_frame: pd.DataFrame) 
     assert result.loc[0, "trades"] == 1
     assert result.loc[0, "sample_size"] == 1
     assert result.loc[0, "avg_return"] == pytest.approx(0.02)
-

--- a/tests/fe/test_polymarket_etl.py
+++ b/tests/fe/test_polymarket_etl.py
@@ -1,12 +1,11 @@
 import sys
-from pathlib import Path
-
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from fe.data.polymarket import etl
+from fe.data.polymarket import etl  # noqa: E402
 
 
 def test_get_retries():


### PR DESCRIPTION
## Summary
- add logging configuration, CLI options, and log pruning support to the Polymarket ETL while normalizing stored order book levels
- schedule the ETL in a daily GitHub Actions workflow that uploads outputs and logs with configurable retention and coverage thresholds
- document workflow configuration and rerun steps while tightening tests to cover log retention

## Testing
- flake8 tests/fe --extend-ignore=E501
- PYTEST_ADDOPTS=--import-mode=importlib pytest tests/fe tests/test_coverage.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693982c8204483268c241667edcc19b3)